### PR TITLE
fix(compute): fix nil-checks in attached_volumes iteration to prevent template errors

### DIFF
--- a/plugins/compute/app/views/compute/instances/_item_details.html.haml
+++ b/plugins/compute/app/views/compute/instances/_item_details.html.haml
@@ -169,6 +169,7 @@
             - root_disk_size = @instance.flavor['disk']
             - unless attached_volumes.empty?
               - attached_volumes.each do |vol|
+                - next if vol.nil?
                 - if vol.attachments&.first&.[]('device') == @instance.root_disk_device_name
                   - root_disk_size = vol.size
             %table.table.datatable
@@ -268,6 +269,7 @@
                     %td{colspan: 2} No volumes attached.
                 - else
                   - attached_volumes.each do |vol|
+                    - next if vol.nil?
                     %tr
                       %td
                         = vol.name


### PR DESCRIPTION
# Summary

This PR improves the handling of attached_volumes in the templates by adding guards against nil entries to prevent runtime errors like:

- undefined method 'attachments' for nil:NilClass
- undefined method 'name' for nil:NilClass

# Changes Made

- Added guards in the  `_item_details.html.haml` for handling of attached_volumes

# Related Issues

- Incident: /incident/ab23289593a2a61094cbb9797bba10de

# Screenshots (if applicable)

![Screenshot 2025-07-04 at 11 36 42](https://github.com/user-attachments/assets/5ed08688-9434-46bb-a886-56e7ed2e93d8)

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
