### PR TITLE
chore(object-storage): changed all api call to V3

### DIFF
--- a/plugins/block_storage/app/services/service_layer/block_storage_service.rb
+++ b/plugins/block_storage/app/services/service_layer/block_storage_service.rb
@@ -10,11 +10,8 @@ module ServiceLayer
     end
 
     def elektron_volumes
-      @elektron_volumes ||= elektron.service("volumev2")
+      @elektron_volumes ||= elektron.service("volumev3")
     end
-
-    def elektron_volumesv3
-      @elektron_volumesv3 ||= elektron.service("volumev3")
-    end
+    
   end
 end

--- a/plugins/block_storage/app/services/service_layer/block_storage_services/volume.rb
+++ b/plugins/block_storage/app/services/service_layer/block_storage_services/volume.rb
@@ -15,7 +15,7 @@ module ServiceLayer
       end
 
       def volumes_detail(filter = {})      
-        elektron_volumesv3.get('volumes/detail', filter, {headers: { 'OpenStack-API-Version' => "volume 3.34" }}).map_to(
+        elektron_volumes.get('volumes/detail', filter, {headers: { 'OpenStack-API-Version' => "volume 3.34" }}).map_to(
           'body.volumes', &volume_map
         )
       end
@@ -72,7 +72,7 @@ module ServiceLayer
       end
 
       def extend_volume_size(id, size)
-        elektron_volumesv3.post("volumes/#{id}/action",{headers: {"OpenStack-API-Version": "volume 3.42"}}) do
+        elektron_volumes.post("volumes/#{id}/action",{headers: {"OpenStack-API-Version": "volume 3.42"}}) do
           {
             'os-extend': {
               'new_size': size
@@ -89,7 +89,7 @@ module ServiceLayer
 
       def upload_volume_to_image(id, options = {})
         # set version to 3.1 to support protected and force 
-        elektron_volumesv3.post("volumes/#{id}/action", {headers: {"OpenStack-API-Version"=> "volume 3.1"}}) do
+        elektron_volumes.post("volumes/#{id}/action", {headers: {"OpenStack-API-Version"=> "volume 3.1"}}) do
           {
             'os-volume_upload_image'=> {
               'image_name' => options['image_name'],


### PR DESCRIPTION
# Summary

* this will change all cinder api `V2` calls to `V3` since `V2` is deprecated and will be removed with the next release
* luckily the `V3` is backward compatible to `V2`

# Changes Made

* changed the `elektron` service endpoint for all api calls to V3

# Related Issues

- Issue 1: #1639 

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
