### PR TITLE
feat(core): colorize log in development

### DIFF
--- a/config/initializers/colorize_logger.rb
+++ b/config/initializers/colorize_logger.rb
@@ -1,0 +1,24 @@
+module ColorizedLogger
+  COLORS = {
+    debug: "\e[0;36m",  # Cyan
+    info: "\e[0;32m",   # Green
+    warn: "\e[1;33m",   # Yellow
+    error: "\e[1;31m",  # Red
+    fatal: "\e[1;31m",  # Red
+    unknown: "\e[0m"    # Default
+  }.freeze
+
+  RESET_COLOR = "\e[0m"
+
+  COLORS.each_key do |level|
+    define_method(level) do |progname = nil, &block|
+      message = progname || (block && block.call)
+      super("#{COLORS[level]}#{message}#{RESET_COLOR}")
+    end
+  end
+end
+
+if Rails.env.development?
+  # Extend Rails logger with colorized logging in development environment
+  Rails.logger.extend(ColorizedLogger)
+end


### PR DESCRIPTION
# Summary

* colorize log for development

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
