### PR TITLE
feat(plugins): add individual autoscaling configuration

### DIFF
--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.js
@@ -70,9 +70,7 @@ const fetchCastellumData =
 function filterShareTypeData(data = {}, isAllShares) {
   const matchingData = {}
   let allShares = isAllShares
-  if (isEmptyObject(data)) {
-    return { data: { "nfs-shares": null }, allShares }
-  }
+
   Object.keys(data).forEach((key) => {
     if (key === "nfs-shares") {
       allShares = true
@@ -82,6 +80,11 @@ function filterShareTypeData(data = {}, isAllShares) {
       matchingData[key] = data[key]
     }
   })
+
+  if (isEmptyObject(matchingData)) {
+    return { data: { "nfs-shares": null }, allShares }
+  }
+  
   return { data: matchingData, allShares }
 }
 

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.js
@@ -72,19 +72,19 @@ function filterShareTypeData(data = {}, isAllShares) {
   let allShares = isAllShares
 
   Object.keys(data).forEach((key) => {
-    if (key === "nfs-shares") {
+    if (key === constants.CASTELLUM_SCOPES.combined) {
       allShares = true
       matchingData[key] = data[key]
-    } else if (key.startsWith("nfs-shares-type")) {
+    } else if (key.startsWith(constants.CASTELLUM_SCOPES.separate)) {
       allShares = false
       matchingData[key] = data[key]
     }
   })
 
   if (isEmptyObject(matchingData)) {
-    return { data: { "nfs-shares": null }, allShares }
+    return { data: { [constants.CASTELLUM_SCOPES.combined]: null }, allShares }
   }
-  
+
   return { data: matchingData, allShares }
 }
 

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.js
@@ -45,7 +45,7 @@ const fetchCastellumData =
       .catch((error) => {
         //for the resource config, a 404 response is not an error; it just shows
         //that autoscaling is disabled on this project resource
-        if (jsonKey == "resources" && error.status === 404) {
+        if (jsonKey == constants.CASTELLUM_AUTOSCALING.key && error.status === 404) {
           dispatch({
             type: constants.RECEIVE_CASTELLUM_DATA,
             key: jsonKey,
@@ -107,7 +107,7 @@ export const configureAutoscaling = (projectID, shareType, config) => (dispatch,
       })
       .then((response) => {
         if (response) {
-          dispatch(fetchCastellumData(projectID, null, "resources"))
+          dispatch(fetchCastellumData(projectID, null, constants.CASTELLUM_AUTOSCALING.key))
           resolve()
         }
       })
@@ -124,7 +124,7 @@ export const disableAutoscaling = (projectID, shareTypes, allShares) => (dispatc
 
     try {
       await Promise.all(deletePromises)
-      dispatch(fetchCastellumData(projectID, null, "resources", allShares))
+      dispatch(fetchCastellumData(projectID, null, constants.CASTELLUM_AUTOSCALING.key, allShares))
     } catch (error) {
       addError(castellumErrorMessage(error))
     }

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.js
@@ -75,14 +75,15 @@ const fetchCastellumData =
       })
   }
 
-function filterShareTypeData(data = {}, isAllShares) {
+export function filterShareTypeData(data = {}, isAllShares) {
   let matchingData = {}
   let allShares = isAllShares
 
   const combinedConfigKey = Object.keys(data).filter((key) => key == constants.CASTELLUM_SCOPES.combined)
   if (combinedConfigKey.length == 1) {
+    const key = constants.CASTELLUM_SCOPES.combined
     allShares = true
-    matchingData = data
+    matchingData = { [key]: data[key] }
     return { data: matchingData, allShares }
   }
 
@@ -98,7 +99,7 @@ function filterShareTypeData(data = {}, isAllShares) {
   return { data: { [constants.CASTELLUM_SCOPES.combined]: null }, allShares }
 }
 
-function filterOperations(data = []) {
+export function filterOperations(data = []) {
   let matchingData = []
   let allShares = true
   const key = "asset_type"

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.js
@@ -28,7 +28,6 @@ const fetchCastellumData =
       .then((response) => {
         const responseData = jsonKey ? response.data[jsonKey] : response.data
         const { data, allShares } = filterShareTypeData(responseData, isAllShares)
-        console.log("DATA", data ? data : "Hi", jsonKey, allShares)
         if (Array.isArray(data)) {
           const shareIDs = data.map((elem) => elem.asset_id).filter((elem) => (elem ? true : false))
           if (shareIDs.length > 0) {
@@ -112,7 +111,7 @@ export const configureAutoscaling = (projectID, shareType, config) => (dispatch,
   )
 }
 
-export const disableAutoscaling = (projectID, shareTypes, isAllShares) => (dispatch, getState) => {
+export const disableAutoscaling = (projectID, shareTypes, allShares) => (dispatch, getState) => {
   confirm("Do you really want to disable the autoscaling configuration on this project?").then(async () => {
     const deletePromises = shareTypes.map((shareType) =>
       ajaxHelper
@@ -122,7 +121,7 @@ export const disableAutoscaling = (projectID, shareTypes, isAllShares) => (dispa
 
     try {
       await Promise.all(deletePromises)
-      dispatch(fetchCastellumData(projectID, null, "resources", isAllShares))
+      dispatch(fetchCastellumData(projectID, null, "resources", allShares))
     } catch (error) {
       addError(castellumErrorMessage(error))
     }

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.test.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.test.js
@@ -75,6 +75,7 @@ describe("filterOperations", () => {
 
     const result = filterOperations(testData)
 
+    // The API returns events either for combined or separate configs.
     expect(result.data).toEqual([{ asset_type: CASTELLUM_SCOPES.combined }])
     expect(result.allShares).toEqual(true)
   })

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.test.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/actions/castellum.test.js
@@ -1,0 +1,102 @@
+import { filterShareTypeData, filterOperations } from "./castellum"
+import { CASTELLUM_SCOPES } from "../constants"
+
+describe("filterShareTypeData", () => {
+  it("should handle all shares data", () => {
+    const testData = {
+      [CASTELLUM_SCOPES.combined]: { someConfig: true },
+    }
+    const isAllShares = undefined
+
+    const result = filterShareTypeData(testData, isAllShares)
+
+    expect(result.data).toEqual(testData)
+    expect(result.allShares).toEqual(true)
+  })
+
+  it("should handle non-matching fields", () => {
+    const testData = {
+      foo: {},
+      bar: {},
+      [CASTELLUM_SCOPES.combined]: {},
+      [`${CASTELLUM_SCOPES.separate}:shareType1`]: {},
+    }
+    const isAllShares = true
+
+    const result = filterShareTypeData(testData, isAllShares)
+
+    expect(result.data).toEqual({
+      [CASTELLUM_SCOPES.combined]: {},
+    })
+    expect(result.allShares).toEqual(true)
+  })
+
+  it("should return default value for empty data", () => {
+    const testData = {}
+    const isAllShares = false
+
+    const result = filterShareTypeData(testData, isAllShares)
+
+    expect(result.data).toEqual({ [CASTELLUM_SCOPES.combined]: null })
+    expect(result.allShares).toEqual(false)
+  })
+
+  it("should handle separate shares data", () => {
+    const testData = {
+      [`${CASTELLUM_SCOPES.separate}:shareType1`]: { someConfig: true },
+      [`${CASTELLUM_SCOPES.separate}:shareType2`]: { someConfig: true },
+    }
+    const isAllShares = undefined
+
+    const result = filterShareTypeData(testData, isAllShares)
+
+    expect(result.data).toEqual(testData)
+    expect(result.allShares).toEqual(false)
+  })
+})
+
+describe("filterOperations", () => {
+  it("should handle combined asset types", () => {
+    const testData = [{ asset_type: CASTELLUM_SCOPES.combined }]
+
+    const result = filterOperations(testData)
+
+    expect(result.data).toEqual(testData)
+    expect(result.allShares).toEqual(true)
+  })
+
+  it("should handle non-matching fields", () => {
+    const testData = [
+      { asset_type: "foo" },
+      { asset_type: "bar" },
+      { asset_type: CASTELLUM_SCOPES.combined },
+      { asset_type: `${CASTELLUM_SCOPES.separate}:shareType1` },
+    ]
+
+    const result = filterOperations(testData)
+
+    expect(result.data).toEqual([{ asset_type: CASTELLUM_SCOPES.combined }])
+    expect(result.allShares).toEqual(true)
+  })
+
+  it("should return default value for empty data", () => {
+    const testData = []
+
+    const result = filterOperations(testData)
+
+    expect(result.data).toEqual([])
+    expect(result.allShares).toEqual(true)
+  })
+
+  it("should handle separate asset types", () => {
+    const testData = [
+      { asset_type: `${CASTELLUM_SCOPES.separate}:shareType1` },
+      { asset_type: `${CASTELLUM_SCOPES.separate}:shareType2` },
+    ]
+
+    const result = filterOperations(testData)
+
+    expect(result.data).toEqual(testData)
+    expect(result.allShares).toEqual(false)
+  })
+})

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/application.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/application.jsx
@@ -220,7 +220,7 @@ const SharedFilesystemApp = (props) => {
           policy.isAllowed("shared_filesystem_storage:share_update") && (
             <Route
               exact
-              path="/autoscaling/configure"
+              path="/autoscaling/configure/:shareType"
               render={(routeProps) => (
                 <CastellumConfigurationEditModal
                   {...routeProps}

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/edit.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/edit.jsx
@@ -185,12 +185,15 @@ export default class CastellumConfigurationEditModal extends React.Component {
   }
 
   getInitialValues() {
-    console.log("PROPS", this.props)
-    const { data, isFetching, receivedAt } = this.props.config
+    const { shareType } = this.props.match.params
+    console.log("PROPSEDIT", this.props, shareType)
+    const { data: config, isFetching, receivedAt } = this.props.config
+    
     if (isFetching || receivedAt == null) {
       //wait until config was loaded
       return null
     }
+    const data = config[shareType]
 
     const cfg = data || {}
     const sec2min = (seconds) => Math.round(seconds / 60)
@@ -271,8 +274,9 @@ export default class CastellumConfigurationEditModal extends React.Component {
       config.size_constraints.minimum_free_is_critical = true
     }
 
+    const { shareType } = this.props.match.params
     this.props
-      .configureAutoscaling(this.props.projectID, config)
+      .configureAutoscaling(this.props.projectID, shareType, config)
       .then(this.close)
       .catch((e) => this.setState({ ...this.state, apiErrors: e }))
   }

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/edit.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/edit.jsx
@@ -9,8 +9,15 @@ const FormBody = ({ close, errors }) => {
   const values = useContext(Form.Context).formValues
 
   let validationError = ""
-  if (values.low_enabled == "false" && values.high_enabled == "false" && values.critical_enabled == "false") {
-    validationError = "To use autoscaling, at least one threshold must be enabled."
+  switch (true) {
+    case values.low_enabled == "false" && values.high_enabled == "false" && values.critical_enabled == "false":
+      validationError = "To use autoscaling, at least one threshold must be enabled."
+      break
+    case values.size_maximum == "":
+      validationError = "Please set the maximum size for extensions."
+      break
+    default:
+      break
   }
 
   return (
@@ -137,7 +144,7 @@ const FormBody = ({ close, errors }) => {
           labelWidth={5}
           labelClass="control-label secondary-label"
         >
-          <Form.Input elementType="input" type="number" min="0" />
+          <Form.Input elementType="input" type="number" required={true} min="0" />
         </Form.ElementHorizontal>
         <Form.ElementHorizontal
           label="Ensure this much free space (GiB):"
@@ -178,6 +185,7 @@ export default class CastellumConfigurationEditModal extends React.Component {
   }
 
   getInitialValues() {
+    console.log("PROPS", this.props)
     const { data, isFetching, receivedAt } = this.props.config
     if (isFetching || receivedAt == null) {
       //wait until config was loaded
@@ -216,7 +224,8 @@ export default class CastellumConfigurationEditModal extends React.Component {
   validate(values) {
     return (
       (values.low_enabled == "true" || values.high_enabled == "true" || values.critical_enabled == "true") &&
-      (values.size_step_single == "true" || values.size_step_percent != "")
+      (values.size_step_single == "true" || values.size_step_percent != "") &&
+      values.size_maximum != ""
     )
   }
 

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/edit.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/edit.jsx
@@ -186,7 +186,6 @@ export default class CastellumConfigurationEditModal extends React.Component {
 
   getInitialValues() {
     const { shareType } = this.props.match.params
-    console.log("PROPSEDIT", this.props, shareType)
     const { data: config, isFetching, receivedAt } = this.props.config
     
     if (isFetching || receivedAt == null) {

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.jsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom"
 import React from "react"
+import {CASTELLUM_SCOPES} from "../../../constants"
 
 const percent = (val) => {
   return `${val}\u{00A0}%`
@@ -91,15 +92,15 @@ export default class CastellumConfigurationView extends React.Component {
     )
 
     function renderConfigForAll(allShares) {
-      const config = configMap["nfs-shares"]
+      const config = configMap[CASTELLUM_SCOPES.combined]
       return (
-        <CastellumConfigurationViewDetails {...props} config={config} shareType={"nfs-shares"} allShares={allShares} />
+        <CastellumConfigurationViewDetails {...props} config={config} shareType={CASTELLUM_SCOPES.combined} allShares={allShares} />
       )
     }
 
     function renderIndividualConfig(allShares) {
       return shareTypeItems.map((shareType) => {
-        const key = `nfs-shares-type:${shareType.name}`
+        const key = `${CASTELLUM_SCOPES.separate}:${shareType.name}`
         const shareConfig = configMap[key]
         return (
           <div key={shareType.name} className="tw-mt-4">

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.jsx
@@ -29,9 +29,11 @@ export default class CastellumConfigurationView extends React.Component {
   constructor(props) {
     super(props)
     const { allShares } = this.props.config
-    const defaultSelected = selectOptions.find((option) => option.value === allShares)
+    const selected = selectOptions.find((option) => option.value === allShares)
+    const defaultSelection = selectOptions[0].label
     this.state = {
-      selected: defaultSelected ? defaultSelected.label : selectOptions[0].label,
+      defaultSelection,
+      selected: selected ? selected.label : defaultSelection,
     }
   }
 
@@ -45,7 +47,7 @@ export default class CastellumConfigurationView extends React.Component {
   handleSelectChange = (event, configMap) => {
     const selectedLabel = event.target.value
     const selectedOption = selectOptions.find((option) => option.label === selectedLabel)
-    const hasAnyConfigs = Object.values(configMap).some((value) => !!value);
+    const hasAnyConfigs = Object.values(configMap).some((value) => !!value)
 
     if (hasAnyConfigs) {
       const shareTypes = Object.keys(configMap)
@@ -58,7 +60,7 @@ export default class CastellumConfigurationView extends React.Component {
 
   render() {
     const props = this.props
-    const { data: configMap, allShares } = this.props.config
+    const { data: configMap } = this.props.config
     const { items: shareTypeItems, isFetching } = this.props.shareTypes
 
     if (isFetching) {
@@ -90,7 +92,6 @@ export default class CastellumConfigurationView extends React.Component {
 
     function renderConfigForAll() {
       const config = configMap["nfs-shares"]
-      console.log("CFG", config)
       return <CastellumConfigurationViewDetails {...props} config={config} shareType={"nfs-shares"} />
     }
 
@@ -110,7 +111,7 @@ export default class CastellumConfigurationView extends React.Component {
     return (
       <div>
         <div>{autoScalingOptions}</div>
-        {this.state.selected == "Individual" ? renderIndividualConfig() : renderConfigForAll()}
+        {this.state.selected == this.state.defaultSelection ? renderConfigForAll() : renderIndividualConfig()}
       </div>
     )
   }
@@ -119,8 +120,6 @@ export default class CastellumConfigurationView extends React.Component {
 class CastellumConfigurationViewDetails extends React.Component {
   render() {
     const config = this.props.config
-
-    console.log("CONFIG2", config)
 
     if (config == null) {
       return (

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.jsx
@@ -76,6 +76,7 @@ export default class CastellumConfigurationView extends React.Component {
       <div className="tw-flex tw-items-center tw-space-x-2">
         <span>Create autoscaling config for</span>
         <select
+          data-testid="autoscalingSelect"
           id="scalingOptions"
           className="select form-control tw-w-48"
           value={this.state.selected.label}

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.jsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom"
 import React from "react"
-import {CASTELLUM_SCOPES} from "../../../constants"
+import { CASTELLUM_SCOPES } from "../../../constants"
 
 const percent = (val) => {
   return `${val}\u{00A0}%`
@@ -94,7 +94,12 @@ export default class CastellumConfigurationView extends React.Component {
     function renderConfigForAll(allShares) {
       const config = configMap[CASTELLUM_SCOPES.combined]
       return (
-        <CastellumConfigurationViewDetails {...props} config={config} shareType={CASTELLUM_SCOPES.combined} allShares={allShares} />
+        <CastellumConfigurationViewDetails
+          {...props}
+          config={config}
+          shareType={CASTELLUM_SCOPES.combined}
+          allShares={allShares}
+        />
       )
     }
 
@@ -129,7 +134,7 @@ class CastellumConfigurationViewDetails extends React.Component {
     if (config == null) {
       return (
         <>
-          <p>Autoscaling is not enabled for this project.</p>
+          <p>Autoscaling is not enabled for this {allShares ? "project." : "share type."}</p>
           <p>
             <Link to={`/autoscaling/configure/${this.props.shareType}`} className="btn btn-primary">
               Configure

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.test.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.test.js
@@ -1,0 +1,72 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { BrowserRouter as Router } from "react-router-dom"
+import CastellumConfigurationView from "./view"
+
+describe("CastellumConfigurationView", () => {
+  let props
+
+  beforeEach(() => {
+    props = {
+      config: { allShares: true, data: {} },
+      loadShareTypesOnce: jest.fn(),
+      disableAutoscaling: jest.fn(),
+      projectID: "1234",
+      shareTypes: { items: [], isFetching: false },
+    }
+  })
+
+  it('should default to rendering the "All" page', () => {
+    render(
+      <Router>
+        <CastellumConfigurationView {...props} />
+      </Router>
+    )
+    expect(screen.getByText("Create autoscaling config for")).not.toBeNull()
+    expect(screen.getByText("All")).not.toBeNull()
+  })
+
+  it('should display "Individual" content and not call disableAutoscaling when swapping to "Individual"', () => {
+    render(
+      <Router>
+        <CastellumConfigurationView {...props} />
+      </Router>
+    )
+    fireEvent.change(screen.getByTestId("autoscalingSelect"), { target: { value: "Individual" } })
+
+    expect(screen.getByText("Individual")).not.toBeNull()
+    expect(props.disableAutoscaling).not.toBeCalled()
+  })
+
+  it('should call disableAutoscaling when swapping to "Individual" with "All" having config', () => {
+    props.config.data = {
+      "nfs-shares": { size_constraints: { minimum_free_is_critical: 30 }, size_steps: { single: true } },
+    }
+    render(
+      <Router>
+        <CastellumConfigurationView {...props} />
+      </Router>
+    )
+    fireEvent.change(screen.getByTestId("autoscalingSelect"), { target: { value: "Individual" } })
+    expect(screen.getByText("Individual")).not.toBeNull()
+    expect(props.disableAutoscaling).toBeCalledWith(props.projectID, ["nfs-shares"], false)
+  })
+
+  it('should call disableAutoscaling when swapping to "All" with "Individual" having config', () => {
+    props.config.data = {
+      [`nfs-shares-type:shareTypeName`]: {
+        size_constraints: { minimum_free_is_critical: 30 },
+        size_steps: { single: true },
+      },
+    }
+    props.config.allShares = false
+    render(
+      <Router>
+        <CastellumConfigurationView {...props} />
+      </Router>
+    )
+    fireEvent.change(screen.getByTestId("autoscalingSelect"), { target: { value: "All" } })
+    expect(screen.getByText("All")).not.toBeNull()
+    expect(props.disableAutoscaling).toBeCalledWith(props.projectID, [`nfs-shares-type:shareTypeName`], true)
+  })
+})

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/operations_list.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/operations_list.jsx
@@ -9,7 +9,7 @@ export default class CastellumOperationsList extends React.Component {
 
   render() {
     const { errorMessage, isFetching, data } = this.props.operations
-    if (isFetching || data == null) {
+    if (isFetching) {
       return (
         <p>
           <span className="spinner" /> Loading...

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/scraping_errors.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/scraping_errors.jsx
@@ -34,28 +34,15 @@ export const columns = [
   { key: "actions", label: "" },
 ]
 
-const AssetWithScrapingError = ({
-  asset,
-  share,
-  handleDelete,
-  handleForceDelete,
-}) => {
-  const {
-    id: shareID,
-    size,
-    usage_percent: usagePercent,
-    scraped_at: scrapedAt,
-    checked,
-  } = asset
+const AssetWithScrapingError = ({ asset, share, handleDelete, handleForceDelete }) => {
+  const { id: shareID, size, usage_percent: usagePercent, scraped_at: scrapedAt, checked } = asset
 
   return (
     <>
       <tr>
         <td className="col-md-4">
           {share ? (
-            <Link to={`/autoscaling/${share.id}/show`}>
-              {share.name || shareID}
-            </Link>
+            <Link to={`/autoscaling/${share.id}/show`}>{share.name || shareID}</Link>
           ) : (
             <div>
               <span className="spinner" /> Loading share data...
@@ -64,11 +51,7 @@ const AssetWithScrapingError = ({
           <div className="small text-muted">{shareID}</div>
         </td>
         <td className="col-md-4">
-          {scrapedAt ? (
-            <PrettyDate date={scrapedAt} />
-          ) : (
-            <span className="text-muted">Never</span>
-          )}
+          {scrapedAt ? <PrettyDate date={scrapedAt} /> : <span className="text-muted">Never</span>}
           {scrapedAt && (
             <div className="small text-muted">
               Reported {usagePercent}&nbsp;% usage of {size}&nbsp;GiB
@@ -101,7 +84,16 @@ const AssetWithScrapingError = ({
 
 export default class CastellumScrapingErrors extends React.Component {
   componentDidMount() {
-    this.props.loadAssetsOnce(this.props.projectID)
+    this.props.loadShareTypesOnce(this.props.projectID)
+    const { data } = this.props.config
+    if (data != null) {
+      const shareTypes = Object.keys(data).filter((key) => data[key] != null)
+      this.loadAssets(shareTypes)
+    }
+  }
+
+  loadAssets(shareTypes) {
+    this.props.loadAssetsOnce(this.props.projectID, shareTypes)
   }
 
   render() {
@@ -114,15 +106,11 @@ export default class CastellumScrapingErrors extends React.Component {
       )
     }
     if (errorMessage) {
-      return (
-        <p className="alert alert-danger">Cannot load assets: {errorMessage}</p>
-      )
+      return <p className="alert alert-danger">Cannot load assets: {errorMessage}</p>
     }
 
     //we are only interested in assets with scraping errors
-    const assets = (data.assets || []).filter(
-      (asset) => asset.checked && asset.checked.error
-    )
+    const assets = (data.assets || []).filter((asset) => asset.checked && asset.checked.error)
     const shares = this.props.shares || []
 
     const forwardProps = {

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/scraping_errors.test.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/scraping_errors.test.js
@@ -1,0 +1,40 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import CastellumScrapingErrors from "./scraping_errors"
+
+describe("CastellumScrapingErrors", () => {
+  let props
+
+  beforeEach(() => {
+    props = {
+      loadShareTypesOnce: jest.fn(),
+      loadAssetsOnce: jest.fn(),
+      projectID: "1234",
+      config: { data: null },
+      assets: { errorMessage: null, isFetching: false, data: null },
+      shares: [],
+      handleDelete: jest.fn(),
+      handleForceDelete: jest.fn(),
+    }
+  })
+
+  it("should not call loadAssetsOnce when config is null", () => {
+    render(<CastellumScrapingErrors {...props} />)
+
+    expect(props.loadShareTypesOnce).toHaveBeenCalledWith(props.projectID)
+    expect(props.loadAssetsOnce).not.toHaveBeenCalled()
+  })
+
+  it("should call loadAssetsOnce with both shareTypes when config has 2 entries", () => {
+    const shareTypes = ["shareType1", "shareType2"]
+    props.config.data = {
+      shareType1: { value: "value1" },
+      shareType2: { value: "value2" },
+    }
+
+    render(<CastellumScrapingErrors {...props} />)
+
+    expect(props.loadShareTypesOnce).toHaveBeenCalledWith(props.projectID)
+    expect(props.loadAssetsOnce).toHaveBeenCalledWith(props.projectID, shareTypes)
+  })
+})

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/tabs.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/tabs.jsx
@@ -31,8 +31,8 @@ export default class CastellumTabs extends React.Component {
   }
 
   render() {
-    const { errorMessage, isFetching, data: config } = this.props.config
-    if (isFetching) {
+    const { errorMessage, isFetching, data: config, receivedAt } = this.props.config
+    if (isFetching || !receivedAt) {
       return (
         <p>
           <span className="spinner" /> Loading...
@@ -40,15 +40,12 @@ export default class CastellumTabs extends React.Component {
       )
     }
     if (errorMessage) {
-      return (
-        <p className="alert alert-danger">
-          Cannot load autoscaling configuration: {errorMessage}
-        </p>
-      )
+      return <p className="alert alert-danger">Cannot load autoscaling configuration: {errorMessage}</p>
     }
 
     const forwardProps = { projectID: this.props.projectId }
     //when autoscaling is disabled, just show the configuration dialog
+    console.log("CONFIGTABS", config)
     if (config == null) {
       return <CastellumConfigurationView {...forwardProps} />
     }
@@ -60,11 +57,7 @@ export default class CastellumTabs extends React.Component {
         <div className="col-sm-2">
           <ul className="nav nav-pills nav-stacked">
             {pages.map((conf, idx) => (
-              <li
-                key={idx}
-                role="presentation"
-                className={idx == this.state.active ? "active" : ""}
-              >
+              <li key={idx} role="presentation" className={idx == this.state.active ? "active" : ""}>
                 <a href="#" onClick={(e) => this.handleSelect(idx, e)}>
                   {conf.label}
                 </a>

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/tabs.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/tabs.jsx
@@ -31,7 +31,7 @@ export default class CastellumTabs extends React.Component {
   }
 
   render() {
-    const { errorMessage, isFetching, data: config, receivedAt } = this.props.config
+    const { data: config, errorMessage, isFetching, receivedAt } = this.props.config
     if (isFetching || !receivedAt) {
       return (
         <p>
@@ -45,8 +45,7 @@ export default class CastellumTabs extends React.Component {
 
     const forwardProps = { projectID: this.props.projectId }
     //when autoscaling is disabled, just show the configuration dialog
-    console.log("CONFIGTABS", config)
-    if (config == null) {
+    if (Object.values(config).every((value) => !value)) {
       return <CastellumConfigurationView {...forwardProps} />
     }
 

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/constants.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/constants.js
@@ -1,82 +1,49 @@
 export const REQUEST_SHARES = "shared_filesystem_storage/shares/REQUEST_SHARES"
 export const RECEIVE_SHARES = "shared_filesystem_storage/shares/RECEIVE_SHARES"
 export const REQUEST_SHARE = "shared_filesystem_storage/shares/REQUEST_SHARE"
-export const REQUEST_SHARE_FAILURE =
-  "shared_filesystem_storage/shares/REQUEST_SHARE_FAILURE"
-export const REQUEST_SHARES_FAILURE =
-  "shared_filesystem_storage/shares/REQUEST_SHARES_FAILURE"
+export const REQUEST_SHARE_FAILURE = "shared_filesystem_storage/shares/REQUEST_SHARE_FAILURE"
+export const REQUEST_SHARES_FAILURE = "shared_filesystem_storage/shares/REQUEST_SHARES_FAILURE"
 export const RECEIVE_SHARE = "shared_filesystem_storage/shares/RECEIVE_SHARE"
-export const REQUEST_DELETE_SHARE =
-  "shared_filesystem_storage/shares/REQUEST_DELETE_SHARE"
-export const DELETE_SHARE_FAILURE =
-  "shared_filesystem_storage/shares/DELETE_SHARE_FAILURE"
-export const DELETE_SHARE_SUCCESS =
-  "shared_filesystem_storage/shares/DELETE_SHARE_SUCCESS"
-export const REQUEST_SHARE_EXPORT_LOCATIONS =
-  "shared_filesystem_storage/shares/REQUEST_SHARE_EXPORT_LOCATIONS"
-export const RECEIVE_SHARE_EXPORT_LOCATIONS =
-  "shared_filesystem_storage/shares/RECEIVE_SHARE_EXPORT_LOCATIONS"
-export const REQUEST_AVAILABLE_ZONES =
-  "shared_filesystem_storage/shares/REQUEST_AVAILABLE_ZONES"
-export const RECEIVE_AVAILABLE_ZONES =
-  "shared_filesystem_storage/shares/RECEIVE_AVAILABLE_ZONES"
-export const REQUEST_AVAILABLE_ZONES_FAILURE =
-  "shared_filesystem_storage/shares/REQUEST_AVAILABLE_ZONES_FAILURE"
-export const SET_SEARCH_TERM =
-  "shared_filesystem_storage/shares/SET_SEARCH_TERM"
+export const REQUEST_DELETE_SHARE = "shared_filesystem_storage/shares/REQUEST_DELETE_SHARE"
+export const DELETE_SHARE_FAILURE = "shared_filesystem_storage/shares/DELETE_SHARE_FAILURE"
+export const DELETE_SHARE_SUCCESS = "shared_filesystem_storage/shares/DELETE_SHARE_SUCCESS"
+export const REQUEST_SHARE_EXPORT_LOCATIONS = "shared_filesystem_storage/shares/REQUEST_SHARE_EXPORT_LOCATIONS"
+export const RECEIVE_SHARE_EXPORT_LOCATIONS = "shared_filesystem_storage/shares/RECEIVE_SHARE_EXPORT_LOCATIONS"
+export const REQUEST_AVAILABLE_ZONES = "shared_filesystem_storage/shares/REQUEST_AVAILABLE_ZONES"
+export const RECEIVE_AVAILABLE_ZONES = "shared_filesystem_storage/shares/RECEIVE_AVAILABLE_ZONES"
+export const REQUEST_AVAILABLE_ZONES_FAILURE = "shared_filesystem_storage/shares/REQUEST_AVAILABLE_ZONES_FAILURE"
+export const SET_SEARCH_TERM = "shared_filesystem_storage/shares/SET_SEARCH_TERM"
 export const SET_SEARCH_IDS = "shared_filesystem_storage/shares/SET_SEARCH_IDS"
 
 // SHARE RULES
-export const REQUEST_SHARE_RULES =
-  "shared_filesystem_storage/shares/REQUEST_SHARE_RULES"
-export const RECEIVE_SHARE_RULES =
-  "shared_filesystem_storage/shares/RECEIVE_SHARE_RULES"
-export const RECEIVE_SHARE_RULE =
-  "shared_filesystem_storage/shares/RECEIVE_SHARE_RULE"
-export const REQUEST_DELETE_SHARE_RULE =
-  "shared_filesystem_storage/shares/REQUEST_DELETE_SHARE_RULE"
-export const DELETE_SHARE_RULE_FAILURE =
-  "shared_filesystem_storage/shares/DELETE_SHARE_RULE_FAILURE"
-export const DELETE_SHARE_RULE_SUCCESS =
-  "shared_filesystem_storage/shares/DELETE_SHARE_RULE_SUCCESS"
-export const DELETE_SHARE_RULES_SUCCESS =
-  "shared_filesystem_storage/shares/DELETE_SHARE_RULES_SUCCESS"
+export const REQUEST_SHARE_RULES = "shared_filesystem_storage/shares/REQUEST_SHARE_RULES"
+export const RECEIVE_SHARE_RULES = "shared_filesystem_storage/shares/RECEIVE_SHARE_RULES"
+export const RECEIVE_SHARE_RULE = "shared_filesystem_storage/shares/RECEIVE_SHARE_RULE"
+export const REQUEST_DELETE_SHARE_RULE = "shared_filesystem_storage/shares/REQUEST_DELETE_SHARE_RULE"
+export const DELETE_SHARE_RULE_FAILURE = "shared_filesystem_storage/shares/DELETE_SHARE_RULE_FAILURE"
+export const DELETE_SHARE_RULE_SUCCESS = "shared_filesystem_storage/shares/DELETE_SHARE_RULE_SUCCESS"
+export const DELETE_SHARE_RULES_SUCCESS = "shared_filesystem_storage/shares/DELETE_SHARE_RULES_SUCCESS"
 
 // SHARE TYPES
-export const RECEIVE_SHARE_TYPES =
-  "shared_filesystem_storage/shares/RECEIVE_SHARE_TYPES"
-export const REQUEST_SHARE_TYPES =
-  "shared_filesystem_storage/shares/REQUEST_SHARE_TYPES"
-export const REQUEST_SHARE_TYPES_FAILURE =
-  "shared_filesystem_storage/shares/REQUEST_SHARE_TYPES_FAILURE"
+export const RECEIVE_SHARE_TYPES = "shared_filesystem_storage/shares/RECEIVE_SHARE_TYPES"
+export const REQUEST_SHARE_TYPES = "shared_filesystem_storage/shares/REQUEST_SHARE_TYPES"
+export const REQUEST_SHARE_TYPES_FAILURE = "shared_filesystem_storage/shares/REQUEST_SHARE_TYPES_FAILURE"
 
 // SHARE_NETWORKS
-export const REQUEST_SHARE_NETWORKS =
-  "shared_filesystem_storage/share_networks/REQUEST_SHARE_NETWORKS"
-export const RECEIVE_SHARE_NETWORKS =
-  "shared_filesystem_storage/share_networks/RECEIVE_SHARE_NETWORKS"
-export const REQUEST_SHARE_NETWORK =
-  "shared_filesystem_storage/share_networks/REQUEST_SHARE_NETWORK"
-export const REQUEST_SHARE_NETWORK_FAILURE =
-  "shared_filesystem_storage/share_networks/REQUEST_SHARE_NETWORK_FAILURE"
-export const REQUEST_SHARE_NETWORKS_FAILURE =
-  "shared_filesystem_storage/share_networks/REQUEST_SHARE_NETWORKS_FAILURE"
-export const RECEIVE_SHARE_NETWORK =
-  "shared_filesystem_storage/share_networks/RECEIVE_SHARE_NETWORK"
-export const REQUEST_DELETE_SHARE_NETWORK =
-  "shared_filesystem_storage/share_networks/REQUEST_DELETE_SHARE_NETWORK"
-export const DELETE_SHARE_NETWORK_FAILURE =
-  "shared_filesystem_storage/share_networks/DELETE_SHARE_NETWORK_FAILURE"
-export const DELETE_SHARE_NETWORK_SUCCESS =
-  "shared_filesystem_storage/share_networks/DELETE_SHARE_NETWORK_SUCCESS"
+export const REQUEST_SHARE_NETWORKS = "shared_filesystem_storage/share_networks/REQUEST_SHARE_NETWORKS"
+export const RECEIVE_SHARE_NETWORKS = "shared_filesystem_storage/share_networks/RECEIVE_SHARE_NETWORKS"
+export const REQUEST_SHARE_NETWORK = "shared_filesystem_storage/share_networks/REQUEST_SHARE_NETWORK"
+export const REQUEST_SHARE_NETWORK_FAILURE = "shared_filesystem_storage/share_networks/REQUEST_SHARE_NETWORK_FAILURE"
+export const REQUEST_SHARE_NETWORKS_FAILURE = "shared_filesystem_storage/share_networks/REQUEST_SHARE_NETWORKS_FAILURE"
+export const RECEIVE_SHARE_NETWORK = "shared_filesystem_storage/share_networks/RECEIVE_SHARE_NETWORK"
+export const REQUEST_DELETE_SHARE_NETWORK = "shared_filesystem_storage/share_networks/REQUEST_DELETE_SHARE_NETWORK"
+export const DELETE_SHARE_NETWORK_FAILURE = "shared_filesystem_storage/share_networks/DELETE_SHARE_NETWORK_FAILURE"
+export const DELETE_SHARE_NETWORK_SUCCESS = "shared_filesystem_storage/share_networks/DELETE_SHARE_NETWORK_SUCCESS"
 
 // SHARE_SERVERS
-export const REQUEST_SHARE_SERVERS =
-  "shared_filesystem_storage/share_networks/REQUEST_SHARE_SERVERS"
-export const RECEIVE_SHARE_SERVERS =
-  "shared_filesystem_storage/share_networks/RECEIVE_SHARE_SERVERS"
-export const REQUEST_SHARE_SERVERS_FAILURE =
-  "shared_filesystem_storage/share_networks/REQUEST_SHARE_SERVERS_FAILURE"
+export const REQUEST_SHARE_SERVERS = "shared_filesystem_storage/share_networks/REQUEST_SHARE_SERVERS"
+export const RECEIVE_SHARE_SERVERS = "shared_filesystem_storage/share_networks/RECEIVE_SHARE_SERVERS"
+export const REQUEST_SHARE_SERVERS_FAILURE = "shared_filesystem_storage/share_networks/REQUEST_SHARE_SERVERS_FAILURE"
 
 // SHARE NETWORK SECURITY SERVICES
 export const REQUEST_SHARE_NETWORK_SECURITY_SERVICES =
@@ -95,36 +62,26 @@ export const DELETE_SHARE_NETWORK_SECURITY_SERVICES_SUCCESS =
   "shared_filesystem_storage/share_networks/DELETE_SHARE_NETWORK_SECURITY_SERVICES_SUCCESS"
 
 // NETWORKS
-export const REQUEST_NETWORKS =
-  "shared_filesystem_storage/networks/REQUEST_NETWORKS"
-export const RECEIVE_NETWORKS =
-  "shared_filesystem_storage/networks/RECEIVE_NETWORKS"
-export const REQUEST_NETWORKS_FAILURE =
-  "shared_filesystem_storage/networks/REQUEST_NETWORKS_FAILURE"
+export const REQUEST_NETWORKS = "shared_filesystem_storage/networks/REQUEST_NETWORKS"
+export const RECEIVE_NETWORKS = "shared_filesystem_storage/networks/RECEIVE_NETWORKS"
+export const REQUEST_NETWORKS_FAILURE = "shared_filesystem_storage/networks/REQUEST_NETWORKS_FAILURE"
 export const TOGGLE_SHARE_NETWORK_IS_NEW_STATUS =
   "shared_filesystem_storage/networks/TOGGLE_SHARE_NETWORK_IS_NEW_STATUS"
 
 // SUBNETS
-export const RECEIVE_SUBNETS =
-  "shared_filesystem_storage/subnets/RECEIVE_SUBNETS"
-export const REQUEST_SUBNETS =
-  "shared_filesystem_storage/subnets/REQUEST_SUBNETS"
-export const REQUEST_SUBNETS_FAILURE =
-  "shared_filesystem_storage/subnets/REQUEST_SUBNETS_FAILURE"
+export const RECEIVE_SUBNETS = "shared_filesystem_storage/subnets/RECEIVE_SUBNETS"
+export const REQUEST_SUBNETS = "shared_filesystem_storage/subnets/REQUEST_SUBNETS"
+export const REQUEST_SUBNETS_FAILURE = "shared_filesystem_storage/subnets/REQUEST_SUBNETS_FAILURE"
 
 // SECURITY SERVICES
-export const REQUEST_SECURITY_SERVICES =
-  "shared_filesystem_storage/security_services/REQUEST_SECURITY_SERVICES"
-export const RECEIVE_SECURITY_SERVICES =
-  "shared_filesystem_storage/security_services/RECEIVE_SECURITY_SERVICES"
-export const REQUEST_SECURITY_SERVICE =
-  "shared_filesystem_storage/security_services/REQUEST_SECURITY_SERVICE"
+export const REQUEST_SECURITY_SERVICES = "shared_filesystem_storage/security_services/REQUEST_SECURITY_SERVICES"
+export const RECEIVE_SECURITY_SERVICES = "shared_filesystem_storage/security_services/RECEIVE_SECURITY_SERVICES"
+export const REQUEST_SECURITY_SERVICE = "shared_filesystem_storage/security_services/REQUEST_SECURITY_SERVICE"
 export const REQUEST_SECURITY_SERVICE_FAILURE =
   "shared_filesystem_storage/security_services/REQUEST_SECURITY_SERVICE_FAILURE"
 export const REQUEST_SECURITY_SERVICES_FAILURE =
   "shared_filesystem_storage/security_services/REQUEST_SECURITY_SERVICES_FAILURE"
-export const RECEIVE_SECURITY_SERVICE =
-  "shared_filesystem_storage/security_services/RECEIVE_SECURITY_SERVICE"
+export const RECEIVE_SECURITY_SERVICE = "shared_filesystem_storage/security_services/RECEIVE_SECURITY_SERVICE"
 export const REQUEST_DELETE_SECURITY_SERVICE =
   "shared_filesystem_storage/security_services/REQUEST_DELETE_SECURITY_SERVICE"
 export const DELETE_SECURITY_SERVICE_FAILURE =
@@ -133,65 +90,45 @@ export const DELETE_SECURITY_SERVICE_SUCCESS =
   "shared_filesystem_storage/security_services/DELETE_SECURITY_SERVICE_SUCCESS"
 
 // REPLICAS
-export const REQUEST_SNAPSHOTS =
-  "shared_filesystem_storage/snapshots/REQUEST_SNAPSHOTS"
-export const RECEIVE_SNAPSHOTS =
-  "shared_filesystem_storage/snapshots/RECEIVE_SNAPSHOTS"
-export const REQUEST_SNAPSHOT =
-  "shared_filesystem_storage/snapshots/REQUEST_SNAPSHOT"
-export const REQUEST_SNAPSHOT_FAILURE =
-  "shared_filesystem_storage/snapshots/REQUEST_SNAPSHOT_FAILURE"
-export const REQUEST_SNAPSHOTS_FAILURE =
-  "shared_filesystem_storage/snapshots/REQUEST_SNAPSHOTS_FAILURE"
-export const RECEIVE_SNAPSHOT =
-  "shared_filesystem_storage/snapshots/RECEIVE_SNAPSHOT"
-export const REQUEST_DELETE_SNAPSHOT =
-  "shared_filesystem_storage/snapshots/REQUEST_DELETE_SNAPSHOT"
-export const DELETE_SNAPSHOT_FAILURE =
-  "shared_filesystem_storage/snapshots/DELETE_SNAPSHOT_FAILURE"
-export const DELETE_SNAPSHOT_SUCCESS =
-  "shared_filesystem_storage/snapshots/DELETE_SNAPSHOT_SUCCESS"
-export const RESET_REPLICA_FETCHING_STATE =
-  "shared_filesystem_storage/snapshots/RESET_REPLICA_FETCHING_STATE"
+export const REQUEST_SNAPSHOTS = "shared_filesystem_storage/snapshots/REQUEST_SNAPSHOTS"
+export const RECEIVE_SNAPSHOTS = "shared_filesystem_storage/snapshots/RECEIVE_SNAPSHOTS"
+export const REQUEST_SNAPSHOT = "shared_filesystem_storage/snapshots/REQUEST_SNAPSHOT"
+export const REQUEST_SNAPSHOT_FAILURE = "shared_filesystem_storage/snapshots/REQUEST_SNAPSHOT_FAILURE"
+export const REQUEST_SNAPSHOTS_FAILURE = "shared_filesystem_storage/snapshots/REQUEST_SNAPSHOTS_FAILURE"
+export const RECEIVE_SNAPSHOT = "shared_filesystem_storage/snapshots/RECEIVE_SNAPSHOT"
+export const REQUEST_DELETE_SNAPSHOT = "shared_filesystem_storage/snapshots/REQUEST_DELETE_SNAPSHOT"
+export const DELETE_SNAPSHOT_FAILURE = "shared_filesystem_storage/snapshots/DELETE_SNAPSHOT_FAILURE"
+export const DELETE_SNAPSHOT_SUCCESS = "shared_filesystem_storage/snapshots/DELETE_SNAPSHOT_SUCCESS"
+export const RESET_REPLICA_FETCHING_STATE = "shared_filesystem_storage/snapshots/RESET_REPLICA_FETCHING_STATE"
 
 // REPLICAS
-export const REQUEST_REPLICAS =
-  "shared_filesystem_storage/snapshots/REQUEST_REPLICAS"
-export const RECEIVE_REPLICAS =
-  "shared_filesystem_storage/snapshots/RECEIVE_REPLICAS"
-export const REQUEST_REPLICA =
-  "shared_filesystem_storage/snapshots/REQUEST_REPLICA"
-export const REQUEST_REPLICA_FAILURE =
-  "shared_filesystem_storage/snapshots/REQUEST_REPLICA_FAILURE"
-export const REQUEST_REPLICAS_FAILURE =
-  "shared_filesystem_storage/snapshots/REQUEST_REPLICAS_FAILURE"
-export const RECEIVE_REPLICA =
-  "shared_filesystem_storage/snapshots/RECEIVE_REPLICA"
-export const REQUEST_DELETE_REPLICA =
-  "shared_filesystem_storage/snapshots/REQUEST_DELETE_REPLICA"
-export const DELETE_REPLICA_FAILURE =
-  "shared_filesystem_storage/snapshots/DELETE_REPLICA_FAILURE"
-export const DELETE_REPLICA_SUCCESS =
-  "shared_filesystem_storage/snapshots/DELETE_REPLICA_SUCCESS"
+export const REQUEST_REPLICAS = "shared_filesystem_storage/snapshots/REQUEST_REPLICAS"
+export const RECEIVE_REPLICAS = "shared_filesystem_storage/snapshots/RECEIVE_REPLICAS"
+export const REQUEST_REPLICA = "shared_filesystem_storage/snapshots/REQUEST_REPLICA"
+export const REQUEST_REPLICA_FAILURE = "shared_filesystem_storage/snapshots/REQUEST_REPLICA_FAILURE"
+export const REQUEST_REPLICAS_FAILURE = "shared_filesystem_storage/snapshots/REQUEST_REPLICAS_FAILURE"
+export const RECEIVE_REPLICA = "shared_filesystem_storage/snapshots/RECEIVE_REPLICA"
+export const REQUEST_DELETE_REPLICA = "shared_filesystem_storage/snapshots/REQUEST_DELETE_REPLICA"
+export const DELETE_REPLICA_FAILURE = "shared_filesystem_storage/snapshots/DELETE_REPLICA_FAILURE"
+export const DELETE_REPLICA_SUCCESS = "shared_filesystem_storage/snapshots/DELETE_REPLICA_SUCCESS"
 // TODO: resync
 
 // ERROR MESSAGES
-export const REQUEST_ERROR_MESSAGES =
-  "shared_filesystem_storage/error_messages/REQUEST_ERROR_MESSAGES"
-export const RECEIVE_ERROR_MESSAGES =
-  "shared_filesystem_storage/error_messages/RECEIVE_ERROR_MESSAGES"
-export const REQUEST_ERROR_MESSAGES_FAILURE =
-  "shared_filesystem_storage/error_messages/REQUEST_ERROR_MESSAGES_FAILURE"
-export const SET_ERROR_MESSAGE_SEARCH_TERM =
-  "shared_filesystem_storage/error_messages/SET_ERROR_MESSAGE_SEARCH_TERM"
+export const REQUEST_ERROR_MESSAGES = "shared_filesystem_storage/error_messages/REQUEST_ERROR_MESSAGES"
+export const RECEIVE_ERROR_MESSAGES = "shared_filesystem_storage/error_messages/RECEIVE_ERROR_MESSAGES"
+export const REQUEST_ERROR_MESSAGES_FAILURE = "shared_filesystem_storage/error_messages/REQUEST_ERROR_MESSAGES_FAILURE"
+export const SET_ERROR_MESSAGE_SEARCH_TERM = "shared_filesystem_storage/error_messages/SET_ERROR_MESSAGE_SEARCH_TERM"
 
 // Castellum
-export const REQUEST_CASTELLUM_DATA =
-  "shared_filesystem_storage/castellum/REQUEST_CASTELLUM_DATA"
-export const RECEIVE_CASTELLUM_DATA =
-  "shared_filesystem_storage/castellum/RECEIVE_CASTELLUM_DATA"
-export const REQUEST_CASTELLUM_DATA_FAILURE =
-  "shared_filesystem_storage/castellum/REQUEST_CASTELLUM_DATA_FAILURE"
+export const REQUEST_CASTELLUM_DATA = "shared_filesystem_storage/castellum/REQUEST_CASTELLUM_DATA"
+export const RECEIVE_CASTELLUM_DATA = "shared_filesystem_storage/castellum/RECEIVE_CASTELLUM_DATA"
+export const REQUEST_CASTELLUM_DATA_FAILURE = "shared_filesystem_storage/castellum/REQUEST_CASTELLUM_DATA_FAILURE"
+// Keys and endpoints
+export const CASTELLUM_SCOPES = { combined: "nfs-shares", separate: "nfs-shares-type" }
+export const CASTELLUM_AUTOSCALING = { key: "resources", endpoint: "/projects" } // includes scrape errors
+export const CASTELLUM_PENDING = { key: "pending_operations", endpoint: "/operations/pending" }
+export const CASTELLUM_RECENTLY_FAILED = { key: "recently_failed_operations", endpoint: "/operations/recently-failed" }
+export const CASTELLUM_RECENTLY_SUCCEEDED = { key: "recently_succeeded_operations", endpoint: "/operations/recently-succeeded" }
 
 //####################### SHARE STATES ########################
 export const SHARE_STATE_CREATING = "creating" //The share is being created.
@@ -209,8 +146,7 @@ const SHARE_PENDING_STATUS = [
   SHARE_STATE_MIGRATING,
   SHARE_STATE_MIGRATING_TO,
 ]
-export const isShareStatusPending = (statusString) =>
-  SHARE_PENDING_STATUS.includes(statusString)
+export const isShareStatusPending = (statusString) => SHARE_PENDING_STATUS.includes(statusString)
 
 export const SHARE_RESET_STATUS = [
   SHARE_STATE_CREATING,

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/constants.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/constants.js
@@ -125,7 +125,7 @@ export const RECEIVE_CASTELLUM_DATA = "shared_filesystem_storage/castellum/RECEI
 export const REQUEST_CASTELLUM_DATA_FAILURE = "shared_filesystem_storage/castellum/REQUEST_CASTELLUM_DATA_FAILURE"
 // Keys and endpoints
 export const CASTELLUM_SCOPES = { combined: "nfs-shares", separate: "nfs-shares-type" }
-export const CASTELLUM_AUTOSCALING = { key: "resources", endpoint: "/projects" } // includes scrape errors
+export const CASTELLUM_AUTOSCALING = { key: "resources", endpoint: "/projects/" } // includes scrape errors
 export const CASTELLUM_PENDING = { key: "pending_operations", endpoint: "/operations/pending" }
 export const CASTELLUM_RECENTLY_FAILED = { key: "recently_failed_operations", endpoint: "/operations/recently-failed" }
 export const CASTELLUM_RECENTLY_SUCCEEDED = { key: "recently_succeeded_operations", endpoint: "/operations/recently-succeeded" }

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/constants.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/constants.js
@@ -125,10 +125,11 @@ export const RECEIVE_CASTELLUM_DATA = "shared_filesystem_storage/castellum/RECEI
 export const REQUEST_CASTELLUM_DATA_FAILURE = "shared_filesystem_storage/castellum/REQUEST_CASTELLUM_DATA_FAILURE"
 // Keys and endpoints
 export const CASTELLUM_SCOPES = { combined: "nfs-shares", separate: "nfs-shares-type" }
-export const CASTELLUM_AUTOSCALING = { key: "resources", endpoint: "/projects/" } // includes scrape errors
+export const CASTELLUM_AUTOSCALING = { key: "resources", endpoint: "/projects/" }
 export const CASTELLUM_PENDING = { key: "pending_operations", endpoint: "/operations/pending" }
 export const CASTELLUM_RECENTLY_FAILED = { key: "recently_failed_operations", endpoint: "/operations/recently-failed" }
 export const CASTELLUM_RECENTLY_SUCCEEDED = { key: "recently_succeeded_operations", endpoint: "/operations/recently-succeeded" }
+export const CASTELLUM_ASSET_SCRAPE_ERRORS = { key: "assets", endpoint: "/projects/:id/assets/"}
 
 //####################### SHARE STATES ########################
 export const SHARE_STATE_CREATING = "creating" //The share is being created.

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/constants.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/constants.js
@@ -129,7 +129,7 @@ export const CASTELLUM_AUTOSCALING = { key: "resources", endpoint: "/projects/" 
 export const CASTELLUM_PENDING = { key: "pending_operations", endpoint: "/operations/pending" }
 export const CASTELLUM_RECENTLY_FAILED = { key: "recently_failed_operations", endpoint: "/operations/recently-failed" }
 export const CASTELLUM_RECENTLY_SUCCEEDED = { key: "recently_succeeded_operations", endpoint: "/operations/recently-succeeded" }
-export const CASTELLUM_ASSET_SCRAPE_ERRORS = { key: "assets", endpoint: "/projects/:id/assets/"}
+export const CASTELLUM_ASSET_SCRAPE = { key: "assets", endpoint: "/projects/:id/assets/"}
 
 //####################### SHARE STATES ########################
 export const SHARE_STATE_CREATING = "creating" //The share is being created.

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/configuration/edit.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/configuration/edit.js
@@ -4,10 +4,9 @@ import CastellumConfigurationEditModal from '../../../components/castellum/confi
 
 export default connect(
   state => ({
-    config: (state.castellum || {})['resources/nfs-shares'],
+    config: (state.castellum || {})['resources'],
   }),
   dispatch => ({
-    configureAutoscaling: (projectID, cfg) => dispatch(configureAutoscaling(projectID, cfg)),
+    configureAutoscaling: (projectID, shareType, cfg) => dispatch(configureAutoscaling(projectID, shareType, cfg)),
   }),
 )(CastellumConfigurationEditModal);
-

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/configuration/edit.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/configuration/edit.js
@@ -1,12 +1,13 @@
-import { connect } from  'react-redux';
-import { configureAutoscaling } from '../../../actions/castellum';
-import CastellumConfigurationEditModal from '../../../components/castellum/configuration/edit';
+import { connect } from "react-redux"
+import { configureAutoscaling } from "../../../actions/castellum"
+import CastellumConfigurationEditModal from "../../../components/castellum/configuration/edit"
+import { CASTELLUM_AUTOSCALING } from "../../../constants"
 
 export default connect(
-  state => ({
-    config: (state.castellum || {})['resources'],
+  (state) => ({
+    config: (state.castellum || {})[CASTELLUM_AUTOSCALING.key],
   }),
-  dispatch => ({
+  (dispatch) => ({
     configureAutoscaling: (projectID, shareType, cfg) => dispatch(configureAutoscaling(projectID, shareType, cfg)),
-  }),
-)(CastellumConfigurationEditModal);
+  })
+)(CastellumConfigurationEditModal)

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/configuration/view.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/configuration/view.js
@@ -9,7 +9,7 @@ export default connect(
     shareTypes: state.shareTypes,
   }),
   (dispatch) => ({
-    disableAutoscaling: (projectID, shareTypes, isAllShares) => dispatch(disableAutoscaling(projectID, shareTypes, isAllShares)),
+    disableAutoscaling: (projectID, shareTypes, allShares) => dispatch(disableAutoscaling(projectID, shareTypes, allShares)),
     loadShareTypesOnce: () => dispatch(fetchShareTypesIfNeeded()),
   })
 )(CastellumConfigurationView)

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/configuration/view.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/configuration/view.js
@@ -2,14 +2,16 @@ import { connect } from "react-redux"
 import CastellumConfigurationView from "../../../components/castellum/configuration/view"
 import { disableAutoscaling } from "../../../actions/castellum"
 import { fetchShareTypesIfNeeded } from "../../../actions/share_types"
+import { CASTELLUM_AUTOSCALING } from "../../../constants"
 
 export default connect(
   (state) => ({
-    config: (state.castellum || {})["resources"],
+    config: (state.castellum || {})[CASTELLUM_AUTOSCALING.key],
     shareTypes: state.shareTypes,
   }),
   (dispatch) => ({
-    disableAutoscaling: (projectID, shareTypes, allShares) => dispatch(disableAutoscaling(projectID, shareTypes, allShares)),
+    disableAutoscaling: (projectID, shareTypes, allShares) =>
+      dispatch(disableAutoscaling(projectID, shareTypes, allShares)),
     loadShareTypesOnce: () => dispatch(fetchShareTypesIfNeeded()),
   })
 )(CastellumConfigurationView)

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/configuration/view.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/configuration/view.js
@@ -9,7 +9,7 @@ export default connect(
     shareTypes: state.shareTypes,
   }),
   (dispatch) => ({
-    disableAutoscaling: (projectID, shareType) => dispatch(disableAutoscaling(projectID, shareType)),
+    disableAutoscaling: (projectID, shareTypes, isAllShares) => dispatch(disableAutoscaling(projectID, shareTypes, isAllShares)),
     loadShareTypesOnce: () => dispatch(fetchShareTypesIfNeeded()),
   })
 )(CastellumConfigurationView)

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/configuration/view.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/configuration/view.js
@@ -1,12 +1,15 @@
-import { connect } from  'react-redux';
-import CastellumConfigurationView from '../../../components/castellum/configuration/view';
-import { disableAutoscaling } from '../../../actions/castellum';
+import { connect } from "react-redux"
+import CastellumConfigurationView from "../../../components/castellum/configuration/view"
+import { disableAutoscaling } from "../../../actions/castellum"
+import { fetchShareTypesIfNeeded } from "../../../actions/share_types"
 
 export default connect(
-  state => ({
-    config: (state.castellum || {})['resources/nfs-shares'],
+  (state) => ({
+    config: (state.castellum || {})["resources"],
+    shareTypes: state.shareTypes,
   }),
-  dispatch => ({
-    disableAutoscaling: (projectID) => dispatch(disableAutoscaling(projectID)),
-  }),
-)(CastellumConfigurationView);
+  (dispatch) => ({
+    disableAutoscaling: (projectID, shareType) => dispatch(disableAutoscaling(projectID, shareType)),
+    loadShareTypesOnce: () => dispatch(fetchShareTypesIfNeeded()),
+  })
+)(CastellumConfigurationView)

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/pending.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/pending.js
@@ -1,18 +1,19 @@
-import { connect } from  'react-redux';
-import CastellumOperationsList from '../../components/castellum/operations_list';
-import { fetchCastellumDataIfNeeded } from '../../actions/castellum';
-import { deleteShare, forceDeleteShare } from '../../actions/shares';
+import { connect } from "react-redux"
+import CastellumOperationsList from "../../components/castellum/operations_list"
+import { fetchCastellumDataIfNeeded } from "../../actions/castellum"
+import { deleteShare, forceDeleteShare } from "../../actions/shares"
+import { CASTELLUM_PENDING } from "../../constants"
 
-const path = '/v1/operations/pending';
+const path = CASTELLUM_PENDING.endpoint
 export default connect(
-  state => ({
-    operations: (state.castellum || {})[path],
-    shares:     (state.shares || {}).items,
+  (state) => ({
+    operations: (state.castellum || {})[CASTELLUM_PENDING.key],
+    shares: (state.shares || {}).items,
   }),
-  dispatch => ({
+  (dispatch) => ({
     loadOpsOnce: (projectID) =>
-      dispatch(fetchCastellumDataIfNeeded(projectID, path.concat(`?project=$id`), 'pending_operations')),
-    handleDelete:      (shareID) => dispatch(deleteShare(shareID)),
-    handleForceDelete: (shareID) => dispatch(forceDeleteShare(shareID))
-  }),
-)(CastellumOperationsList);
+      dispatch(fetchCastellumDataIfNeeded(projectID, path.concat(`?project=${projectID}`), "pending_operations")),
+    handleDelete: (shareID) => dispatch(deleteShare(shareID)),
+    handleForceDelete: (shareID) => dispatch(forceDeleteShare(shareID)),
+  })
+)(CastellumOperationsList)

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/pending.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/pending.js
@@ -12,7 +12,7 @@ export default connect(
   }),
   (dispatch) => ({
     loadOpsOnce: (projectID) =>
-      dispatch(fetchCastellumDataIfNeeded(projectID, path.concat(`?project=${projectID}`), "pending_operations")),
+      dispatch(fetchCastellumDataIfNeeded(projectID, path.concat(`?project=${projectID}`), CASTELLUM_PENDING.key)),
     handleDelete: (shareID) => dispatch(deleteShare(shareID)),
     handleForceDelete: (shareID) => dispatch(forceDeleteShare(shareID)),
   })

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/pending.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/pending.js
@@ -3,7 +3,7 @@ import CastellumOperationsList from '../../components/castellum/operations_list'
 import { fetchCastellumDataIfNeeded } from '../../actions/castellum';
 import { deleteShare, forceDeleteShare } from '../../actions/shares';
 
-const path = 'resources/nfs-shares/operations/pending';
+const path = '/v1/operations/pending';
 export default connect(
   state => ({
     operations: (state.castellum || {})[path],
@@ -11,7 +11,7 @@ export default connect(
   }),
   dispatch => ({
     loadOpsOnce: (projectID) =>
-      dispatch(fetchCastellumDataIfNeeded(projectID, path, 'pending_operations')),
+      dispatch(fetchCastellumDataIfNeeded(projectID, path.concat(`?project=$id`), 'pending_operations')),
     handleDelete:      (shareID) => dispatch(deleteShare(shareID)),
     handleForceDelete: (shareID) => dispatch(forceDeleteShare(shareID))
   }),

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/recently_failed.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/recently_failed.js
@@ -2,16 +2,17 @@ import { connect } from  'react-redux';
 import CastellumOperationsList from '../../components/castellum/operations_list';
 import { fetchCastellumDataIfNeeded } from '../../actions/castellum';
 import { deleteShare, forceDeleteShare } from '../../actions/shares';
+import { CASTELLUM_RECENTLY_FAILED } from '../../constants';
 
-const path = 'resources/nfs-shares/operations/recently-failed';
+const path = CASTELLUM_RECENTLY_FAILED.endpoint;
 export default connect(
   state => ({
-    operations: (state.castellum || {})[path],
+    operations: (state.castellum || {})[CASTELLUM_RECENTLY_FAILED.key],
     shares:     (state.shares || {}).items,
   }),
   dispatch => ({
     loadOpsOnce: (projectID) =>
-      dispatch(fetchCastellumDataIfNeeded(projectID, path, 'recently_failed_operations')),
+      dispatch(fetchCastellumDataIfNeeded(projectID, path.concat(`?project=${projectID}`), CASTELLUM_RECENTLY_FAILED.key)),
     handleDelete:      (shareID) => dispatch(deleteShare(shareID)),
     handleForceDelete: (shareID) => dispatch(forceDeleteShare(shareID))
   }),

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/recently_succeeded.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/recently_succeeded.js
@@ -2,16 +2,17 @@ import { connect } from  'react-redux';
 import CastellumOperationsList from '../../components/castellum/operations_list';
 import { fetchCastellumDataIfNeeded } from '../../actions/castellum';
 import { deleteShare, forceDeleteShare } from '../../actions/shares';
+import { CASTELLUM_RECENTLY_SUCCEEDED } from '../../constants';
 
-const path = 'resources/nfs-shares/operations/recently-succeeded';
+const path = CASTELLUM_RECENTLY_SUCCEEDED.endpoint;
 export default connect(
   state => ({
-    operations: (state.castellum || {})[path],
+    operations: (state.castellum || {})[CASTELLUM_RECENTLY_SUCCEEDED.key],
     shares:     (state.shares || {}).items,
   }),
   dispatch => ({
     loadOpsOnce: (projectID) =>
-      dispatch(fetchCastellumDataIfNeeded(projectID, path, 'recently_succeeded_operations')),
+      dispatch(fetchCastellumDataIfNeeded(projectID, path.concat(`?project=${projectID}`), CASTELLUM_RECENTLY_SUCCEEDED.key)),
     handleDelete:      (shareID) => dispatch(deleteShare(shareID)),
     handleForceDelete: (shareID) => dispatch(forceDeleteShare(shareID))
   }),

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/scraping_errors.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/scraping_errors.js
@@ -1,18 +1,21 @@
-import { connect } from  'react-redux';
-import CastellumScrapingErrors from '../../components/castellum/scraping_errors';
-import { fetchCastellumDataIfNeeded } from '../../actions/castellum';
-import { deleteShare, forceDeleteShare } from '../../actions/shares';
+import { connect } from "react-redux"
+import CastellumScrapingErrors from "../../components/castellum/scraping_errors"
+import { fetchCastellumDataIfNeeded, fetchAssetsIfNeeded } from "../../actions/castellum"
+import { deleteShare, forceDeleteShare } from "../../actions/shares"
+import { CASTELLUM_AUTOSCALING } from "../../constants"
+import { CASTELLUM_ASSET_SCRAPE } from "../../constants"
 
-const path = 'assets/nfs-shares';
+const path = CASTELLUM_ASSET_SCRAPE.endpoint
 export default connect(
-  state => ({
-    assets: (state.castellum || {})[path],
+  (state) => ({
+    config: (state.castellum || {})[CASTELLUM_AUTOSCALING.key],
+    assets: (state.castellum || {})[CASTELLUM_ASSET_SCRAPE.key],
     shares: (state.shares || {}).items,
   }),
-  dispatch => ({
-    loadAssetsOnce: (projectID) =>
-      dispatch(fetchCastellumDataIfNeeded(projectID, path)),
-    handleDelete:      (shareID) => dispatch(deleteShare(shareID)),
-    handleForceDelete: (shareID) => dispatch(forceDeleteShare(shareID))
-  }),
-)(CastellumScrapingErrors);
+  (dispatch) => ({
+    loadShareTypesOnce: (projectID) => dispatch(fetchCastellumDataIfNeeded(projectID, null, CASTELLUM_AUTOSCALING.key)),
+    loadAssetsOnce: (projectID, shareTypes) => dispatch(fetchAssetsIfNeeded(projectID, shareTypes)),
+    handleDelete: (shareID) => dispatch(deleteShare(shareID)),
+    handleForceDelete: (shareID) => dispatch(forceDeleteShare(shareID)),
+  })
+)(CastellumScrapingErrors)

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/tabs.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/tabs.js
@@ -2,11 +2,13 @@ import { connect } from "react-redux"
 import CastellumTabs from "../../components/castellum/tabs"
 import { fetchCastellumDataIfNeeded } from "../../actions/castellum"
 
+const path = "projects/"
 export default connect(
   (state) => ({
     config: (state.castellum || {})["resources"],
   }),
   (dispatch) => ({
-    loadResourceConfigOnce: (projectID) => dispatch(fetchCastellumDataIfNeeded(projectID, null, "resources")),
+    loadResourceConfigOnce: (projectID) =>
+      dispatch(fetchCastellumDataIfNeeded(projectID, null, "resources")),
   })
 )(CastellumTabs)

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/tabs.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/tabs.js
@@ -2,7 +2,6 @@ import { connect } from "react-redux"
 import CastellumTabs from "../../components/castellum/tabs"
 import { fetchCastellumDataIfNeeded } from "../../actions/castellum"
 
-const path = "projects/"
 export default connect(
   (state) => ({
     config: (state.castellum || {})["resources"],

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/tabs.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/tabs.js
@@ -1,15 +1,12 @@
-import { connect } from  'react-redux';
-import CastellumTabs from '../../components/castellum/tabs';
-import {
-  fetchCastellumDataIfNeeded,
-} from '../../actions/castellum';
+import { connect } from "react-redux"
+import CastellumTabs from "../../components/castellum/tabs"
+import { fetchCastellumDataIfNeeded } from "../../actions/castellum"
 
 export default connect(
-  state => ({
-    config: (state.castellum || {})['resources/nfs-shares'],
+  (state) => ({
+    config: (state.castellum || {})["resources"],
   }),
-  dispatch => ({
-    loadResourceConfigOnce: (projectID) =>
-      dispatch(fetchCastellumDataIfNeeded(projectID, 'resources/nfs-shares')),
-  }),
-)(CastellumTabs);
+  (dispatch) => ({
+    loadResourceConfigOnce: (projectID) => dispatch(fetchCastellumDataIfNeeded(projectID, null, "resources")),
+  })
+)(CastellumTabs)

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/tabs.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/containers/castellum/tabs.js
@@ -1,13 +1,14 @@
 import { connect } from "react-redux"
 import CastellumTabs from "../../components/castellum/tabs"
 import { fetchCastellumDataIfNeeded } from "../../actions/castellum"
+import { CASTELLUM_AUTOSCALING } from "../../constants"
 
 export default connect(
   (state) => ({
-    config: (state.castellum || {})["resources"],
+    config: (state.castellum || {})[CASTELLUM_AUTOSCALING.key],
   }),
   (dispatch) => ({
     loadResourceConfigOnce: (projectID) =>
-      dispatch(fetchCastellumDataIfNeeded(projectID, null, "resources")),
+      dispatch(fetchCastellumDataIfNeeded(projectID, null, CASTELLUM_AUTOSCALING.key)),
   })
 )(CastellumTabs)

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/reducers/castellum.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/reducers/castellum.js
@@ -14,6 +14,7 @@ const initialCastellumState = {
   [constants.CASTELLUM_PENDING.key]: initialStateForPath,
   [constants.CASTELLUM_RECENTLY_SUCCEEDED.key]: initialStateForPath,
   [constants.CASTELLUM_RECENTLY_FAILED.key]: initialStateForPath,
+  [constants.CASTELLUM_ASSET_SCRAPE.key]: initialStateForPath,
 }
 
 const requestData = (state, { key, requestedAt }) => ({

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/reducers/castellum.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/reducers/castellum.js
@@ -10,11 +10,10 @@ const initialStateForPath = {
 }
 
 const initialCastellumState = {
-  "assets/nfs-shares": initialStateForPath,
-  resources: initialStateForPath ,
-  "resources/nfs-shares/operations/pending": initialStateForPath,
-  "resources/nfs-shares/operations/recently-succeeded": initialStateForPath,
-  "resources/nfs-shares/operations/recently-failed": initialStateForPath,
+  [constants.CASTELLUM_AUTOSCALING.key]: initialStateForPath,
+  [constants.CASTELLUM_PENDING.key]: initialStateForPath,
+  [constants.CASTELLUM_RECENTLY_SUCCEEDED.key]: initialStateForPath,
+  [constants.CASTELLUM_RECENTLY_FAILED.key]: initialStateForPath,
 }
 
 const requestData = (state, { key, requestedAt }) => ({
@@ -33,7 +32,7 @@ const requestDataFailure = (state, { key, message, receivedAt }) => ({
     data: null,
     errorMessage: message,
     isFetching: false,
-    receivedAt
+    receivedAt,
   },
 })
 

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/reducers/castellum.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/reducers/castellum.js
@@ -8,9 +8,10 @@ const initialStateForPath = {
   allShares: true,
   receivedAt: null,
 }
+
 const initialCastellumState = {
   "assets/nfs-shares": initialStateForPath,
-  resources: { "nfs-shares": initialStateForPath },
+  resources: initialStateForPath ,
   "resources/nfs-shares/operations/pending": initialStateForPath,
   "resources/nfs-shares/operations/recently-succeeded": initialStateForPath,
   "resources/nfs-shares/operations/recently-failed": initialStateForPath,

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/reducers/castellum.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/reducers/castellum.js
@@ -1,58 +1,66 @@
-import * as constants from '../constants';
+import * as constants from "../constants"
 
 const initialStateForPath = {
   data: null,
   errorMessage: null,
   isFetching: false,
   requestedAt: null,
+  allShares: true,
   receivedAt: null,
-};
+}
 const initialCastellumState = {
-  'assets/nfs-shares': initialStateForPath,
-  'resources/nfs-shares': initialStateForPath,
-  'resources/nfs-shares/operations/pending': initialStateForPath,
-  'resources/nfs-shares/operations/recently-succeeded': initialStateForPath,
-  'resources/nfs-shares/operations/recently-failed': initialStateForPath,
-};
+  "assets/nfs-shares": initialStateForPath,
+  resources: { "nfs-shares": initialStateForPath },
+  "resources/nfs-shares/operations/pending": initialStateForPath,
+  "resources/nfs-shares/operations/recently-succeeded": initialStateForPath,
+  "resources/nfs-shares/operations/recently-failed": initialStateForPath,
+}
 
-const requestData = (state, {path, requestedAt}) => ({
+const requestData = (state, { key, requestedAt }) => ({
   ...state,
-  [path]: {
+  [key]: {
     ...initialStateForPath,
     isFetching: true,
     requestedAt,
   },
-});
+})
 
-const requestDataFailure = (state, {path, message}) => ({
+const requestDataFailure = (state, { key, message, receivedAt }) => ({
   ...state,
-  [path]: {
-    ...state[path],
+  [key]: {
+    ...state[key],
     data: null,
     errorMessage: message,
     isFetching: false,
+    receivedAt
   },
-});
+})
 
-const receiveData = (state, {path, data, receivedAt}) => ({
+const receiveData = (state, { key, data, allShares, receivedAt }) => ({
   ...state,
-  [path]: {
-    ...state[path],
+  [key]: {
+    ...state[key],
     data,
     errorMessage: null,
     isFetching: false,
+    allShares,
     receivedAt,
   },
-});
+})
 
 export const castellum = (state, action) => {
   if (state == null) {
-    state = initialCastellumState;
+    state = initialCastellumState
   }
+
   switch (action.type) {
-    case constants.REQUEST_CASTELLUM_DATA: return requestData(state, action);
-    case constants.RECEIVE_CASTELLUM_DATA: return receiveData(state, action);
-    case constants.REQUEST_CASTELLUM_DATA_FAILURE: return requestDataFailure(state, action);
-    default: return state;
+    case constants.REQUEST_CASTELLUM_DATA:
+      return requestData(state, action)
+    case constants.RECEIVE_CASTELLUM_DATA:
+      return receiveData(state, action)
+    case constants.REQUEST_CASTELLUM_DATA_FAILURE:
+      return requestDataFailure(state, action)
+    default:
+      return state
   }
-};
+}


### PR DESCRIPTION

Castellum allows the configuration for either "All" share types or for "Individual" share types.
This PR adds this option to the UI.

# Changes Made

- Add selection between both configuration types.
- If a user swaps from "All" config to "Individual" config or vise versa with an active config, the swap will only be performed after the user agrees to reset the active configurations.
- If a user swaps from "All" config to "Individual" config or vise versa without an active config, the swap will be performed without asking the user to reset the existing configurations.
- Adjust autoscaling and asset events to the new structure.
- Fix autoscaling configuration modal. `max_size` is now a required field. It caused malformed API requests before.

# Screenshots (if applicable)

- Active config for all share types:
<img width="754" height="243" alt="image" src="https://github.com/user-attachments/assets/2bf4a0e4-35d2-4653-9786-cb64ba1a9ed3" />

- Active individual configs:
<img width="714" height="450" alt="image" src="https://github.com/user-attachments/assets/be2b42da-ee9d-422e-acd7-b313c82d7214" />

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
