### PR TITLE
feat(image): introduce domain config to hide public images

### DIFF
--- a/config/support/domain_config.yaml
+++ b/config/support/domain_config.yaml
@@ -35,6 +35,7 @@ domains:
       - internal_help_links
       - terms_of_use
       - networking_backup
+      - public_images
     terms_of_use_name: "marioworld_terms"
     floating_ip_networks:
       - FloatingIP-external-marioworld-01

--- a/plugins/image/app/javascript/widgets/app/components/os_images/list.jsx
+++ b/plugins/image/app/javascript/widgets/app/components/os_images/list.jsx
@@ -3,7 +3,7 @@ import { policy } from "lib/policy"
 import { SearchField } from "lib/components/search_field"
 import Item from "./item"
 import { AjaxPaginate } from "lib/components/ajax_paginate"
-import React, { useState, useEffect, useCallback, useMemo } from "react"
+import React, { useEffect, useMemo } from "react"
 
 const TableRowFadeTransition = ({ children, ...props }) => (
   <CSSTransition {...props} timeout={200} classNames="css-transition-fade">
@@ -11,7 +11,6 @@ const TableRowFadeTransition = ({ children, ...props }) => (
   </CSSTransition>
 )
 
-// upgrade to functional components (6.2.24)
 const List = ({
   items,
   active,
@@ -31,6 +30,13 @@ const List = ({
 }) => {
   const availableVisibilityFilters = useMemo(() => {
     if (!visibilityCounts) return []
+    // Disable public filters if the flag is set
+    // this comes from the domain config
+    if (otherProps.disablePublicFilters) {
+      setActiveVisibilityFilter("private")
+      return Object.keys(visibilityCounts).filter((k) => k !== "public")
+    }
+
     return Object.keys(visibilityCounts)
   }, [visibilityCounts])
 
@@ -79,16 +85,6 @@ const List = ({
             ))}
           </>
         )}
-        {/* <div style={{ display: "flex", flexGrow: 1, justifyContent: "end" }}>
-          {isFetching ? (
-            <div>
-              <span className="spinner" />
-            </div>
-          ) : (
-            visibilityCounts[activeVisibilityFilter] || 0
-          )}{" "}
-          Images
-        </div> */}
       </div>
       {!policy.isAllowed("image:image_list") ? (
         <span>You are not allowed to see this page</span>
@@ -152,167 +148,3 @@ const List = ({
 }
 
 export default List
-
-// export default class List extends React.Component {
-//   state = {
-//     visibilityFilters: ["private", "public", "shared"],
-//     activeFilter: null,
-//   }
-
-//   UNSAFE_componentWillReceiveProps(nextProps) {
-//     if (nextProps.items && nextProps.items.length > 0) {
-//       // build available filters array
-//       let availableFilters = this.state.visibilityFilters.slice()
-//       for (let i of nextProps.items) {
-//         if (availableFilters.indexOf(i.visibility) < 0)
-//           availableFilters.push(i.visibility)
-//       }
-//       availableFilters.sort()
-//       let index = availableFilters.indexOf("public")
-//       if (index < 0) index = 0
-
-//       let activeFilter = this.state.activeFilter || availableFilters[index]
-//       // set available filters and set active filter to the first
-//       this.setState({
-//         visibilityFilters: availableFilters,
-//         activeFilter: activeFilter,
-//       })
-//     }
-//     this.loadDependencies(nextProps)
-//   }
-
-//   componentDidMount() {
-//     // load dependencies unless already loaded
-//     this.loadDependencies(this.props)
-//   }
-
-//   loadDependencies(props) {
-//     if (!props.active) return
-//     props.loadOsImagesOnce()
-//   }
-
-//   changeActiveFilter = (name) => {
-//     // set active filter in state to the name
-//     this.setState({ activeFilter: name })
-//   }
-
-//   filterItems = () => {
-//     // filter items dependent on the active filter
-//     let items = this.props.items.filter(
-//       (i) => this.state.activeFilter == i.visibility
-//     )
-
-//     if (!this.props.searchTerm) return items
-
-//     // search term is given -> filter items dependent on the search term
-//     const regex = new RegExp(this.props.searchTerm.trim(), "i")
-//     return items.filter(
-//       (i) => `${i.name} ${i.id} ${i.format} ${i.status}`.search(regex) >= 0
-//     )
-//   }
-
-//   toolbar = () => {
-//     // return null if no items available
-//     if (this.props.items.length <= 0) return null
-
-//     return (
-//       <div className="toolbar">
-//         <SearchField
-//           onChange={(term) => this.props.searchOsImages(term)}
-//           placeholder="name, ID, format or status"
-//           text="Searches by name, ID, format or status in visible images list only.
-//                 Entering a search term will automatically start loading the next pages
-//                 and filter the loaded items using the search term. Emptying the search
-//                 input field will show all currently loaded items."
-//         />
-//         {this.state.visibilityFilters.length > 1 && ( // show filter checkboxes
-//           <>
-//             <span className="toolbar-input-divider"></span>
-//             <label>Show:</label>
-//             {this.state.visibilityFilters.map((name, index) => (
-//               <label className="radio-inline" key={index}>
-//                 <input
-//                   type="radio"
-//                   onChange={() => this.changeActiveFilter(name)}
-//                   checked={this.state.activeFilter == name}
-//                 />
-//                 {name}
-//               </label>
-//             ))}
-//           </>
-//         )}
-//       </div>
-//     )
-//   }
-
-//   renderTable = () => {
-//     let items = this.filterItems()
-
-//     return (
-//       <div>
-//         <table className="table shares">
-//           <thead>
-//             <tr>
-//               <th></th>
-//               <th>Name</th>
-//               <th>Format</th>
-//               <th>Size</th>
-//               <th>Created</th>
-//               <th>Status</th>
-//               <th></th>
-//             </tr>
-//           </thead>
-//           <TransitionGroup component="tbody">
-//             {items && items.length > 0 ? (
-//               items.map(
-//                 (image, index) =>
-//                   !image.isHidden && (
-//                     <TableRowFadeTransition key={index}>
-//                       <Item
-//                         {...this.props}
-//                         image={image}
-//                         handleAccept={this.props.handleAccept}
-//                         handleReject={this.props.handleReject}
-//                         activeTab={this.props.activeTab}
-//                       />
-//                     </TableRowFadeTransition>
-//                   )
-//               )
-//             ) : (
-//               <TableRowFadeTransition>
-//                 <tr>
-//                   <td colSpan="7">
-//                     {this.props.isFetching ? (
-//                       <span className="spinner" />
-//                     ) : (
-//                       "No images found."
-//                     )}
-//                   </td>
-//                 </tr>
-//               </TableRowFadeTransition>
-//             )}
-//           </TransitionGroup>
-//         </table>
-
-//         <AjaxPaginate
-//           hasNext={this.props.hasNext}
-//           isFetching={this.props.isFetching}
-//           onLoadNext={this.props.loadNext}
-//         />
-//       </div>
-//     )
-//   }
-
-//   render() {
-//     return (
-//       <div>
-//         {this.toolbar()}
-//         {!policy.isAllowed("image:image_list") ? (
-//           <span>You are not allowed to see this page</span>
-//         ) : (
-//           this.renderTable()
-//         )}
-//       </div>
-//     )
-//   }
-// }

--- a/plugins/image/app/javascript/widgets/app/components/os_images/list.jsx
+++ b/plugins/image/app/javascript/widgets/app/components/os_images/list.jsx
@@ -31,12 +31,12 @@ const List = ({
   const availableVisibilityFilters = useMemo(() => {
     if (!visibilityCounts) return []
     // Disable public filters if the flag is set
-    // this comes from the domain config
+    // disablePublicFilters comes from the domain config
     if (otherProps.disablePublicFilters) {
-      setActiveVisibilityFilter("private")
+      if (activeVisibilityFilter === "public") setActiveVisibilityFilter("private")
+      // filter out public images
       return Object.keys(visibilityCounts).filter((k) => k !== "public")
     }
-
     return Object.keys(visibilityCounts)
   }, [visibilityCounts])
 

--- a/plugins/image/app/javascript/widgets/app/components/os_images/list.jsx
+++ b/plugins/image/app/javascript/widgets/app/components/os_images/list.jsx
@@ -30,9 +30,9 @@ const List = ({
 }) => {
   const availableVisibilityFilters = useMemo(() => {
     if (!visibilityCounts) return []
-    // Disable public filters if the flag is set
-    // disablePublicFilters comes from the domain config
-    if (otherProps.disablePublicFilters) {
+    // disable public images if the flag is set
+    // disablePublicImages comes from the domain config
+    if (otherProps.disablePublicImages === "true") {
       if (activeVisibilityFilter === "public") setActiveVisibilityFilter("private")
       // filter out public images
       return Object.keys(visibilityCounts).filter((k) => k !== "public")

--- a/plugins/image/app/javascript/widgets/app/containers/os_images/list_available.js
+++ b/plugins/image/app/javascript/widgets/app/containers/os_images/list_available.js
@@ -5,7 +5,7 @@ import imageActions from "../../actions/os_images"
 const actions = imageActions("available")
 
 export default connect(
-  (state, ownProps) => ({
+  (state) => ({
     activeTab: "available",
     visibilityCounts: state.available.visibilityCounts,
     activeVisibilityFilter: state.available.activeVisibilityFilter,

--- a/plugins/image/app/javascript/widgets/app/containers/os_images/list_suggested.js
+++ b/plugins/image/app/javascript/widgets/app/containers/os_images/list_suggested.js
@@ -9,7 +9,7 @@ import {
 } from "../../actions/image_members"
 
 export default connect(
-  (state, ownProps) => ({
+  (state) => ({
     activeTab: "suggested",
     visibilityCounts: state.suggested.visibilityCounts,
     activeVisibilityFilter: state.suggested.activeVisibilityFilter,

--- a/plugins/image/app/views/image/ng/images/app.html.haml
+++ b/plugins/image/app/views/image/ng/images/app.html.haml
@@ -5,7 +5,7 @@
     project_parent_id: @active_project.parent_id,
     scoped_domain_name: @scoped_domain_name,
     launch_instance_url: plugin('compute').new_instance_path,
-    disable_public_filters: @domain_config.feature_hidden?('public_images') }
+    disable_public_images: @domain_config.feature_hidden?('public_images') }
 
 
 %div.buttons{class: modal? ? 'modal-footer' : ''}

--- a/plugins/image/app/views/image/ng/images/app.html.haml
+++ b/plugins/image/app/views/image/ng/images/app.html.haml
@@ -1,5 +1,4 @@
 %div{class: modal? ? 'modal-body' : ''}
-  %h1 Images
   = javascript_include_tag "image_app_widget",
     data: { url: plugin('image').root_path,
     project_parent_id: @active_project.parent_id,

--- a/plugins/image/app/views/image/ng/images/app.html.haml
+++ b/plugins/image/app/views/image/ng/images/app.html.haml
@@ -1,9 +1,11 @@
 %div{class: modal? ? 'modal-body' : ''}
+  %h1 Images
   = javascript_include_tag "image_app_widget",
     data: { url: plugin('image').root_path,
     project_parent_id: @active_project.parent_id,
     scoped_domain_name: @scoped_domain_name,
-    launch_instance_url: plugin('compute').new_instance_path}
+    launch_instance_url: plugin('compute').new_instance_path,
+    disable_public_filters: @domain_config.feature_hidden?('public_images') }
 
 
 %div.buttons{class: modal? ? 'modal-footer' : ''}


### PR DESCRIPTION
# Summary

* this introduce the possibility to hide public images for specific domain with the `doman_config`

# Related Issues

- Issue 1: #1667 

# Screenshots (if applicable)

<img width="1505" height="290" alt="image" src="https://github.com/user-attachments/assets/dccc3c07-c73a-4026-8344-54342e43607a" />

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
