### PR TITLE
fix(key-manager): fixes download secret file formatting issue

### DIFF
--- a/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/secretDetails.jsx
+++ b/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/secretDetails.jsx
@@ -102,10 +102,8 @@ const SecretDetails = () => {
         setPayloadString(data)
       }
       if (payloadRequested) {
-        //Downloading the payload content as a file
-        const fileData =
-        typeof data === "string" ? data : String(data) // Use raw string
-        const blob = new Blob([fileData], {
+        //Downloading the payload content as a file, put the raw data into a blob
+        const blob = new Blob([data], {
           type: secret?.data?.content_types?.default,
         })
         const url = URL.createObjectURL(blob)

--- a/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/secretDetails.jsx
+++ b/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/secretDetails.jsx
@@ -103,7 +103,8 @@ const SecretDetails = () => {
       }
       if (payloadRequested) {
         //Downloading the payload content as a file
-        const fileData = JSON.stringify(data)
+        const fileData =
+        typeof data === "string" ? data : String(data) // Use raw string
         const blob = new Blob([fileData], {
           type: secret?.data?.content_types?.default,
         })


### PR DESCRIPTION
# Summary

This PR resolves a problem where downloading a secret resulted in a file with unwanted formatting changes. The downloaded file previously included additional double quotes (") around the secret. Moreover, all newlines within the secret were replaced by the literal string \r\n.

# Changes Made

- Write the raw secret payload directly to the file, without using` JSON.stringify `or any transformation that would change the content.

# Related Issues

- Issue 1: #1621 

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
