### PR TITLE
chore(lbaas): switch from keymanager service layer to osAPI

### DIFF
--- a/plugins/lbaas2/app/controllers/lbaas2/loadbalancers/listeners_controller.rb
+++ b/plugins/lbaas2/app/controllers/lbaas2/loadbalancers/listeners_controller.rb
@@ -104,50 +104,6 @@ module Lbaas2
         render json: { errors: e.message }, status: "500"
       end
 
-      def containers
-        containers =
-          services.key_manager.containers(sort: "created:desc", limit: 3000)
-        containers = { items: [] } if containers.blank?
-        selectContainers =
-          containers[:items].map do |c|
-            { label: "#{c.name} (#{c.id})", value: c.container_ref }
-          end
-
-        render json: { containers: selectContainers }
-      rescue Exception => e
-        render json: { errors: e.message }, status: "500"
-      end
-
-      def secrets
-        # collect secrets by type
-        secretsCertificate =
-          services.key_manager.secrets(
-            sort: "created:desc",
-            secret_type: ::KeyManager::Secret::Type::CERTIFICATE,
-            limit: 50,
-          )
-        secretsOpaque =
-          services.key_manager.secrets(
-            sort: "created:desc",
-            secret_type: ::KeyManager::Secret::Type::OPAQUE,
-            limit: 50,
-          )
-
-        total =
-          secretsCertificate.fetch(:total, 0).to_i +
-            secretsOpaque.fetch(:total, 0).to_i
-        secrets =
-          secretsCertificate.fetch(:items, []) + secretsOpaque.fetch(:items, [])
-        selectSecrets =
-          secrets.map do |c|
-            { label: "#{c.name} (#{c.secret_ref})", value: c.secret_ref }
-          end
-
-        render json: { secrets: selectSecrets, total: total }
-      rescue Exception => e
-        render json: { errors: e.message }, status: "500"
-      end
-
       def itemsWithoutDefaultPoolForSelect
         listeners =
           services

--- a/plugins/lbaas2/app/javascript/widgets/app/actions/apiClient.js
+++ b/plugins/lbaas2/app/javascript/widgets/app/actions/apiClient.js
@@ -1,0 +1,5 @@
+import { createAjaxHelper } from "lib/ajax_helper"
+import { widgetBasePath } from "lib/widget"
+
+const baseURL = widgetBasePath("lbaas2")
+export default createAjaxHelper({ baseURL })

--- a/plugins/lbaas2/app/javascript/widgets/app/actions/healthMonitor.js
+++ b/plugins/lbaas2/app/javascript/widgets/app/actions/healthMonitor.js
@@ -1,12 +1,9 @@
-import { ajaxHelper } from "lib/ajax_helper"
+import apiClient from "./apiClient"
 
 export const fetchHealthmonitor = (lbID, poolID, healthmonitorID, options) => {
   return new Promise((handleSuccess, handleError) => {
-    ajaxHelper
-      .get(
-        `/loadbalancers/${lbID}/pools/${poolID}/healthmonitors/${healthmonitorID}`,
-        { params: options }
-      )
+    apiClient
+      .get(`/loadbalancers/${lbID}/pools/${poolID}/healthmonitors/${healthmonitorID}`, { params: options })
       .then((response) => {
         handleSuccess(response.data)
       })
@@ -18,7 +15,7 @@ export const fetchHealthmonitor = (lbID, poolID, healthmonitorID, options) => {
 
 export const postHealthMonitor = (lbID, poolID, values) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
+    apiClient
       .post(`/loadbalancers/${lbID}/pools/${poolID}/healthmonitors`, {
         healthmonitor: values,
       })
@@ -33,11 +30,8 @@ export const postHealthMonitor = (lbID, poolID, values) => {
 
 export const putHealthmonitor = (lbID, poolID, healthmonitorID, values) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
-      .put(
-        `/loadbalancers/${lbID}/pools/${poolID}/healthmonitors/${healthmonitorID}`,
-        { healthmonitor: values }
-      )
+    apiClient
+      .put(`/loadbalancers/${lbID}/pools/${poolID}/healthmonitors/${healthmonitorID}`, { healthmonitor: values })
       .then((response) => {
         handleSuccess(response.data)
       })
@@ -49,10 +43,8 @@ export const putHealthmonitor = (lbID, poolID, healthmonitorID, values) => {
 
 export const deleteHealthmonitor = (lbID, poolID, healthmonitorID) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
-      .delete(
-        `/loadbalancers/${lbID}/pools/${poolID}/healthmonitors/${healthmonitorID}`
-      )
+    apiClient
+      .delete(`/loadbalancers/${lbID}/pools/${poolID}/healthmonitors/${healthmonitorID}`)
       .then((response) => {
         handleSuccess(response.data)
       })

--- a/plugins/lbaas2/app/javascript/widgets/app/actions/l7Policy.js
+++ b/plugins/lbaas2/app/javascript/widgets/app/actions/l7Policy.js
@@ -1,8 +1,8 @@
-import { ajaxHelper } from "lib/ajax_helper"
+import apiClient from "./apiClient"
 
 export const fetchL7Policies = (lbID, listenerID, options) => {
   return new Promise((handleSuccess, handleError) => {
-    ajaxHelper
+    apiClient
       .get(`/loadbalancers/${lbID}/listeners/${listenerID}/l7policies`, {
         params: options,
       })
@@ -17,10 +17,8 @@ export const fetchL7Policies = (lbID, listenerID, options) => {
 
 export const fetchL7Policy = (lbID, listenerID, l7PolicyID) => {
   return new Promise((handleSuccess, handleError) => {
-    ajaxHelper
-      .get(
-        `/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7PolicyID}`
-      )
+    apiClient
+      .get(`/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7PolicyID}`)
       .then((response) => {
         handleSuccess(response.data)
       })
@@ -32,7 +30,7 @@ export const fetchL7Policy = (lbID, listenerID, l7PolicyID) => {
 
 export const postL7Policy = (lbID, listenerID, values) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
+    apiClient
       .post(`/loadbalancers/${lbID}/listeners/${listenerID}/l7policies`, {
         l7policy: values,
       })
@@ -47,11 +45,8 @@ export const postL7Policy = (lbID, listenerID, values) => {
 
 export const putL7Policy = (lbID, listenerID, l7policyID, values) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
-      .put(
-        `/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7policyID}`,
-        { l7policy: values }
-      )
+    apiClient
+      .put(`/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7policyID}`, { l7policy: values })
       .then((response) => {
         handleSuccess(response.data)
       })
@@ -63,10 +58,8 @@ export const putL7Policy = (lbID, listenerID, l7policyID, values) => {
 
 export const deleteL7Policy = (lbID, listenerID, l7policyID) => {
   return new Promise((handleSuccess, handleErrors) => {
-    return ajaxHelper
-      .delete(
-        `/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7policyID}`
-      )
+    return apiClient
+      .delete(`/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7policyID}`)
       .then((response) => {
         handleSuccess(response.data)
       })

--- a/plugins/lbaas2/app/javascript/widgets/app/actions/l7Rule.js
+++ b/plugins/lbaas2/app/javascript/widgets/app/actions/l7Rule.js
@@ -1,12 +1,9 @@
-import { ajaxHelper } from "lib/ajax_helper"
+import apiClient from "./apiClient"
 
 export const fetchL7Rules = (lbID, listenerID, l7Policy, options) => {
   return new Promise((handleSuccess, handleError) => {
-    ajaxHelper
-      .get(
-        `/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7Policy}/l7rules`,
-        { params: options }
-      )
+    apiClient
+      .get(`/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7Policy}/l7rules`, { params: options })
       .then((response) => {
         handleSuccess(response.data)
       })
@@ -18,10 +15,8 @@ export const fetchL7Rules = (lbID, listenerID, l7Policy, options) => {
 
 export const fetchL7Rule = (lbID, listenerID, l7PolicyID, l7RuleID) => {
   return new Promise((handleSuccess, handleError) => {
-    ajaxHelper
-      .get(
-        `/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7PolicyID}/l7rules/${l7RuleID}`
-      )
+    apiClient
+      .get(`/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7PolicyID}/l7rules/${l7RuleID}`)
       .then((response) => {
         handleSuccess(response.data)
       })
@@ -33,11 +28,8 @@ export const fetchL7Rule = (lbID, listenerID, l7PolicyID, l7RuleID) => {
 
 export const postL7Rule = (lbID, listenerID, l7PolicyID, values) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
-      .post(
-        `/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7PolicyID}/l7rules`,
-        { l7rule: values }
-      )
+    apiClient
+      .post(`/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7PolicyID}/l7rules`, { l7rule: values })
       .then((response) => {
         handleSuccess(response.data)
       })
@@ -49,11 +41,10 @@ export const postL7Rule = (lbID, listenerID, l7PolicyID, values) => {
 
 export const putL7Rule = (lbID, listenerID, l7PolicyID, l7ruleID, values) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
-      .put(
-        `/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7PolicyID}/l7rules/${l7ruleID}`,
-        { l7rule: values }
-      )
+    apiClient
+      .put(`/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7PolicyID}/l7rules/${l7ruleID}`, {
+        l7rule: values,
+      })
       .then((response) => {
         handleSuccess(response.data)
       })
@@ -65,10 +56,8 @@ export const putL7Rule = (lbID, listenerID, l7PolicyID, l7ruleID, values) => {
 
 export const deleteL7Rule = (lbID, listenerID, l7PolicyID, l7RuleID) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
-      .delete(
-        `/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7PolicyID}/l7rules/${l7RuleID}`
-      )
+    apiClient
+      .delete(`/loadbalancers/${lbID}/listeners/${listenerID}/l7policies/${l7PolicyID}/l7rules/${l7RuleID}`)
       .then((response) => {
         handleSuccess(response.data)
       })

--- a/plugins/lbaas2/app/javascript/widgets/app/actions/loadbalancer.js
+++ b/plugins/lbaas2/app/javascript/widgets/app/actions/loadbalancer.js
@@ -1,8 +1,8 @@
-import { ajaxHelper } from "lib/ajax_helper"
+import apiClient from "./apiClient"
 
 export const fetchAvailabilityZones = () => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
+    apiClient
       .get(`/loadbalancers/availability-zones`)
       .then((response) => {
         handleSuccess(response.data)
@@ -15,7 +15,7 @@ export const fetchAvailabilityZones = () => {
 
 export const fetchLoadbalancers = (options) => {
   return new Promise((handleSuccess, handleError) => {
-    ajaxHelper
+    apiClient
       .get(`/loadbalancers`, { params: options })
       .then((response) => {
         handleSuccess(response.data)
@@ -28,7 +28,7 @@ export const fetchLoadbalancers = (options) => {
 
 export const fetchLoadbalancer = (id) => {
   return new Promise((handleSuccess, handleError) => {
-    ajaxHelper
+    apiClient
       .get(`/loadbalancers/${id}`)
       .then((response) => {
         handleSuccess(response.data)
@@ -41,7 +41,7 @@ export const fetchLoadbalancer = (id) => {
 
 export const postLoadbalancer = (values) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
+    apiClient
       .post("/loadbalancers/", { loadbalancer: values })
       .then((response) => {
         handleSuccess(response.data)
@@ -54,7 +54,7 @@ export const postLoadbalancer = (values) => {
 
 export const putLoadbalancer = (lbID, values) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
+    apiClient
       .put(`/loadbalancers/${lbID}`, { loadbalancer: values })
       .then((response) => {
         handleSuccess(response.data)
@@ -67,7 +67,7 @@ export const putLoadbalancer = (lbID, values) => {
 
 export const deleteLoadbalancer = (id) => {
   return new Promise((handleSuccess, handleErrors) => {
-    return ajaxHelper
+    return apiClient
       .delete(`/loadbalancers/${id}`)
       .then((response) => {
         handleSuccess(response.data)
@@ -80,7 +80,7 @@ export const deleteLoadbalancer = (id) => {
 
 export const fetchPrivateNetworks = () => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
+    apiClient
       .get(`/loadbalancers/private-networks`)
       .then((response) => {
         handleSuccess(response.data)
@@ -93,7 +93,7 @@ export const fetchPrivateNetworks = () => {
 
 export const fetchSubnets = (id) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
+    apiClient
       .get(`/loadbalancers/private-networks/${id}/subnets`)
       .then((response) => {
         handleSuccess(response.data)
@@ -106,7 +106,7 @@ export const fetchSubnets = (id) => {
 
 export const fetchFloatingIPs = () => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
+    apiClient
       .get(`/loadbalancers/fips`)
       .then((response) => {
         handleSuccess(response.data)
@@ -119,7 +119,7 @@ export const fetchFloatingIPs = () => {
 
 export const fetchLoadbalancerDevice = (id) => {
   return new Promise((handleSuccess, handleError) => {
-    ajaxHelper
+    apiClient
       .get(`/loadbalancers/${id}/device`)
       .then((response) => {
         handleSuccess(response.data)
@@ -132,7 +132,7 @@ export const fetchLoadbalancerDevice = (id) => {
 
 export const putAttachFIP = (lbID, values) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
+    apiClient
       .put(`/loadbalancers/${lbID}/attach_fip`, values)
       .then((response) => {
         handleSuccess(response.data)
@@ -145,7 +145,7 @@ export const putAttachFIP = (lbID, values) => {
 
 export const putDetachFIP = (lbID, values) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
+    apiClient
       .put(`/loadbalancers/${lbID}/detach_fip`, values)
       .then((response) => {
         handleSuccess(response.data)

--- a/plugins/lbaas2/app/javascript/widgets/app/actions/pool.js
+++ b/plugins/lbaas2/app/javascript/widgets/app/actions/pool.js
@@ -1,8 +1,8 @@
-import { ajaxHelper } from "lib/ajax_helper"
+import apiClient from "./apiClient"
 
 export const fetchPools = (lbID, options) => {
   return new Promise((handleSuccess, handleError) => {
-    ajaxHelper
+    apiClient
       .get(`/loadbalancers/${lbID}/pools`, { params: options })
       .then((response) => {
         handleSuccess(response.data)
@@ -15,7 +15,7 @@ export const fetchPools = (lbID, options) => {
 
 export const fetchPool = (lbID, poolID) => {
   return new Promise((handleSuccess, handleError) => {
-    ajaxHelper
+    apiClient
       .get(`/loadbalancers/${lbID}/pools/${poolID}`)
       .then((response) => {
         handleSuccess(response.data)
@@ -28,7 +28,7 @@ export const fetchPool = (lbID, poolID) => {
 
 export const postPool = (lbID, values) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
+    apiClient
       .post(`/loadbalancers/${lbID}/pools`, { pool: values })
       .then((response) => {
         handleSuccess(response.data)
@@ -41,7 +41,7 @@ export const postPool = (lbID, values) => {
 
 export const putPool = (lbID, poolID, values) => {
   return new Promise((handleSuccess, handleErrors) => {
-    ajaxHelper
+    apiClient
       .put(`/loadbalancers/${lbID}/pools/${poolID}`, { pool: values })
       .then((response) => {
         handleSuccess(response.data)
@@ -54,7 +54,7 @@ export const putPool = (lbID, poolID, values) => {
 
 export const deletePool = (lbID, poolID) => {
   return new Promise((handleSuccess, handleErrors) => {
-    return ajaxHelper
+    return apiClient
       .delete(`/loadbalancers/${lbID}/pools/${poolID}`)
       .then((response) => {
         handleSuccess(response.data)
@@ -67,7 +67,7 @@ export const deletePool = (lbID, poolID) => {
 
 export const fetchPoolsForSelect = (lbID) => {
   return new Promise((handleSuccess, handleError) => {
-    ajaxHelper
+    apiClient
       .get(`/loadbalancers/${lbID}/pools/items_for_select`)
       .then((response) => {
         handleSuccess(response.data)

--- a/plugins/lbaas2/config/policy.json
+++ b/plugins/lbaas2/config/policy.json
@@ -29,8 +29,6 @@
   "lbaas2:listener_create": "rule:lbaas2_context_is_editor",
   "lbaas2:listener_update": "rule:lbaas2_context_is_editor",
   "lbaas2:listener_delete": "rule:lbaas2_context_is_editor",
-  "lbaas2:listener_containers": "rule:lbaas2_context_is_editor",
-  "lbaas2:listener_secrets": "rule:lbaas2_context_is_editor",
   "lbaas2:listener_itemsForSelect": "rule:lbaas2_context_is_editor",
   "lbaas2:listener_itemsWithoutDefaultPoolForSelect": "rule:lbaas2_context_is_editor",
 

--- a/plugins/lbaas2/config/routes.rb
+++ b/plugins/lbaas2/config/routes.rb
@@ -17,8 +17,6 @@ Lbaas2::Engine.routes.draw do
               module: :loadbalancers,
               only: %i[index show create update destroy] do
       collection do
-        get "containers" => "listeners#containers"
-        get "secrets" => "listeners#secrets"
         get "items_for_select" => "listeners#itemsForSelect"
         get "items_no_def_pool_for_select" =>
               "listeners#itemsWithoutDefaultPoolForSelect"

--- a/plugins/lbaas2/spec/controllers/listeners_controller_spec.rb
+++ b/plugins/lbaas2/spec/controllers/listeners_controller_spec.rb
@@ -162,38 +162,6 @@ describe Lbaas2::Loadbalancers::ListenersController, type: :controller do
     end
   end
 
-  describe "GET 'containers'" do
-    before :each do
-      allow_any_instance_of(ServiceLayer::KeyManagerService).to receive(
-        :containers,
-      ).and_return([])
-    end
-
-    it_behaves_like "GET action with editor context" do
-      subject do
-        @default_params = default_params
-        @extra_params = {}
-        @path = "containers"
-      end
-    end
-  end
-
-  describe "GET 'secrets'" do
-    before :each do
-      allow_any_instance_of(ServiceLayer::KeyManagerService).to receive(
-        :secrets,
-      ).and_return({ items: [], total: 0 })
-    end
-
-    it_behaves_like "GET action with editor context" do
-      subject do
-        @default_params = default_params
-        @extra_params = {}
-        @path = "secrets"
-      end
-    end
-  end
-
   describe "GET 'itemsWithoutDefaultPoolForSelect'" do
     before :each do
       listeners =

--- a/plugins/lbaas2/spec/controllers/members_controller_spec.rb
+++ b/plugins/lbaas2/spec/controllers/members_controller_spec.rb
@@ -847,9 +847,6 @@ describe Lbaas2::Loadbalancers::Pools::MembersController, type: :controller do
         :elektron,
       ).and_return(lbs)
 
-      allow_any_instance_of(ServiceLayer::KeyManagerService).to receive(
-        :containers,
-      ).and_return([])
       allow_any_instance_of(ServiceLayer::NetworkingService).to receive(
         :ports,
       ).and_return([])


### PR DESCRIPTION
# Summary

This PR decouples LBaaS from the old Key Manager plugin by replacing its secret-fetching call with the Elektra osAPI client, enabling safe decommissioning of the plugin.

# Changes Made

- Removed the listener actions to fetch secrets and containers (containers was a left over)
- Implement the same login in the listener action to fetch secrets in javascript with the osAPI client.
- Remove all references and tests.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
