### PR TITLE
fix(key-manager): displays order link on secret details panel

### DIFF
--- a/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/secretDetails.jsx
+++ b/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/secretDetails.jsx
@@ -61,7 +61,7 @@ const SecretDetails = () => {
   // Query to find the order that generated this secret
   const orderQuery = useQuery({
     queryKey: ["orderBySecretRef", secretId],
-    queryFn: () => findOrderBySecretRef(secretId),
+    queryFn: findOrderBySecretRef,
     enabled: !!secretId,
     onSuccess: (data) => {
       setGeneratingOrder(data)
@@ -164,9 +164,15 @@ const SecretDetails = () => {
         {secret?.isLoading && !secret?.data ? (
           <HintLoading />
         ) : secret?.isError ? (
-          <Message variant="danger">
-            {`${secret?.error?.statusCode}, ${secret?.error?.message}`}
-          </Message>
+          (!secret?.error?.statusCode && secret?.error?.message === '[object Object]') ? (
+            <Message variant="danger">
+              404: Secret not found
+            </Message>
+          ) : (
+            <Message variant="danger">
+              {`${secret?.error?.statusCode}, ${secret?.error?.message}`}
+            </Message>
+          )
         ) : secret?.data ? (
           <>
             <DataGrid columns={2}>
@@ -243,15 +249,14 @@ const SecretDetails = () => {
               secret?.data?.content_types?.default
             ) && (
               <>
-                {payloadString && (
-                  <>
-                    <SecretText
-                      label="Payload"
-                      value={payloadString}
-
-                    />
-                  </>
-                )}
+               {payloadString && (
+                <SecretText
+                  label="Payload"
+                  disableClear
+                  disablePaste
+                  value={payloadString}
+                />
+               )}
               </>
             )}
             {metadata?.isLoading && !metadata?.data ? (

--- a/plugins/keymanagerng/app/javascript/widgets/app/secretActions.js
+++ b/plugins/keymanagerng/app/javascript/widgets/app/secretActions.js
@@ -31,9 +31,6 @@ export const fetchSecret = (uuid) => {
     .then((response) => {
       return response?.data
     })
-    .catch((error) => {
-      return error
-    })
 }
 
 export const getSecretMetadata = ({ queryKey }) => {


### PR DESCRIPTION
# Summary

In this PR, there are some fixes and improvements for orders management tab in key manager. 

# Changes Made
- First of all, the order link is now displayed correctly in the secret details panel when the secret is generated based on a single order.
- In the case that the secret has a 404 error status, the AJAX helper was showing “[object Object]” as the error text; I replaced that with a meaningful “Not Found” error message.
- The third improvement concerns the secret text panel: I disabled the Clear and Paste functions, since this panel is only meant for reading secret detail information.

# Related Issues

No issue is created. Related to Epic:
https://github.com/SAP-cloud-infrastructure/elektra/issues/1693

# Screenshots (if applicable)

![9FB31A41-82B1-4179-B1E6-D1899F4DBDC6](https://github.com/user-attachments/assets/48ca86d7-d83b-4a96-b3f5-8528e92b11a0)

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
