### PR TITLE
chore(core): add sign_out for oauth to logout link

### DIFF
--- a/app/views/application/_nav.html.haml
+++ b/app/views/application/_nav.html.haml
@@ -43,8 +43,10 @@
                   = link_to "App Credentials", plugin('identity').app_credentials_path 
                 %li.divider
               %li
+                - # https://oauth2-proxy.github.io/oauth2-proxy/features/endpoints/#sign-out
+                - redirect_url = Rails.env.production? ? "https://auth.#{region}.cloud.sap/oauth2/sign_out?rd=#{main_app.landing_page_url}" : main_app.landing_page_url
                 = link_to 'Log out', monsoon_openstack_auth.logout_path(domain_fid: @scoped_domain_fid || params[:domain_id],
-                  domain_name: @scoped_domain_name, redirect_to: main_app.landing_page_url)
+                  domain_name: @scoped_domain_name, redirect_to: redirect_url)
 
         %li.dropdown
           %a.nav-highlight.dropdown-toggle{"aria-expanded" => "false", "data-toggle" => "dropdown", :href => "#", :role => "button"}


### PR DESCRIPTION
# Summary

* this will add the sign_out for oauth to invalidate the oauth token also

# Related Issues

- closes Issue : #1627

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
