### PR TITLE
fix(compute): get all images like the images plugin does

### DIFF
--- a/plugins/compute/app/controllers/compute/instances_controller.rb
+++ b/plugins/compute/app/controllers/compute/instances_controller.rb
@@ -133,10 +133,11 @@ module Compute
       @flavors = services.compute.flavors
       
       # images
-      all_images = services.image.all_images # all images
-      project_images = services.image.all_images({"owner" => @scoped_project_id}) # to be sure to load also all images that are related to the project
+      all_private_images = services.image.all_images({visibility: "private"})
+      all_shared_images =  services.image.all_images({visibility: "shared"})
+      all_public_images =  services.image.all_images({visibility: "public"})
       # Merge and remove duplicates based on ID
-      @images = (all_images + project_images).uniq { |image| image.id }
+      @images = (all_private_images + all_shared_images + all_public_images).uniq { |image| image.id }
 
       @fixed_ip_ports = services.networking.fixed_ip_ports
       @subnets = services.networking.subnets

--- a/plugins/image/app/controllers/image/os_images_controller.rb
+++ b/plugins/image/app/controllers/image/os_images_controller.rb
@@ -7,7 +7,7 @@ module Image
         paginatable(per_page: 15) do |pagination_options|
           services.image.images(filter_params.merge(pagination_options))
         end
-
+      
       # this is relevant in case an ajax paginate call is made.
       # in this case we don't render the layout, only the list!
       if request.xhr?


### PR DESCRIPTION
# Summary

* get all images like the images plugin does
* this will hopefully fix the problem that in some projects images are missing that are shown in the images plugin

# Related Issues

- Issue: #1728

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
