### PR TITLE
chore(kubernetes): use mountpoint prop in API client to prevent broken calls on plugin path changes

### DIFF
--- a/plugins/kubernetes_ng/app/javascript/widgets/app/App.tsx
+++ b/plugins/kubernetes_ng/app/javascript/widgets/app/App.tsx
@@ -1,22 +1,23 @@
 import React, { StrictMode } from "react"
 import { AppShellProvider } from "@cloudoperators/juno-ui-components"
 import { RouterProvider } from "@tanstack/react-router"
-import { router } from "./router"
+import { createAppRouter } from "./router"
 import styles from "./styles.scss?inline"
 
-const rootElement = document.getElementById("kubernetes_ng_app_widget")
+interface AppProps {
+  basepath: string
+  mountpoint: string
+}
 
-export default function App() {
-  const basePath = rootElement?.dataset.basepath || "/"
+export default function App(props: AppProps) {
+  const router = createAppRouter(props.mountpoint)
 
   return (
-    <>
-      <AppShellProvider theme="theme-light">
-        <style>{styles}</style>
-        <StrictMode>
-          <RouterProvider basepath={basePath} context={{}} router={router} />
-        </StrictMode>
-      </AppShellProvider>
-    </>
+    <AppShellProvider theme="theme-light">
+      <style>{styles}</style>
+      <StrictMode>
+        <RouterProvider basepath={props.basepath} context={{}} router={router} />
+      </StrictMode>
+    </AppShellProvider>
   )
 }

--- a/plugins/kubernetes_ng/app/javascript/widgets/app/apiClient.ts
+++ b/plugins/kubernetes_ng/app/javascript/widgets/app/apiClient.ts
@@ -3,24 +3,6 @@ import { widgetBasePath } from "lib/widget"
 import { Cluster } from "./types/clusters"
 import { defaultCluster, errorCluster, unknownStatusCluster } from "./mocks/data"
 
-const baseURL = widgetBasePath("kubernetes_ng")
-const apiClient = createAjaxHelper({ baseURL })
-
-const shootApi = {
-  getClusters: () =>
-    apiClient.get<{ data: Cluster[] }>("/kubernetes-ng/api/clusters/").then((response) => response.data),
-
-  getClusterByName: (name: string) =>
-    apiClient.get<{ data: Cluster }>(`/kubernetes-ng/api/clusters/${name}/`).then((response) => response.data),
-}
-
-const permissionsApi = {
-  getPermissions: () =>
-    apiClient
-      .get<{ data: Record<string, boolean> | undefined }>("/kubernetes-ng/api/permissions/shoots/")
-      .then((response) => response.data),
-}
-
 export const gardenerTestApi = {
   getClusters: () => Promise.resolve([defaultCluster, errorCluster, unknownStatusCluster]),
   getClusterByName: (name: string) => {
@@ -35,8 +17,25 @@ export const gardenerTestApi = {
   getPermissions: () => Promise.resolve({ list: true, create: true, delete: true }),
 }
 
-export const gardenerApi = {
-  gardener: { ...shootApi, ...permissionsApi },
+export function createGardenerApi(mountpoint: string) {
+  const baseURL = widgetBasePath(mountpoint)
+  const apiClient = createAjaxHelper({ baseURL })
+
+  const shootApi = {
+    getClusters: () => apiClient.get<{ data: Cluster[] }>("/api/clusters/").then((res) => res.data),
+
+    getClusterByName: (name: string) =>
+      apiClient.get<{ data: Cluster }>(`/api/clusters/${name}/`).then((res) => res.data),
+  }
+
+  const permissionsApi = {
+    getPermissions: () =>
+      apiClient.get<{ data: Record<string, boolean> | undefined }>("/api/permissions/shoots/").then((res) => res.data),
+  }
+
+  return {
+    gardener: { ...shootApi, ...permissionsApi },
+  }
 }
 
-export type GardenerApi = typeof gardenerApi
+export type GardenerApi = ReturnType<typeof createGardenerApi>

--- a/plugins/kubernetes_ng/app/javascript/widgets/app/router.ts
+++ b/plugins/kubernetes_ng/app/javascript/widgets/app/router.ts
@@ -1,6 +1,6 @@
 import { createRouter } from "@tanstack/react-router"
 import { routeTree } from "./routeTree.gen"
-import { gardenerApi } from "./apiClient"
+import { createGardenerApi } from "./apiClient"
 
 // Register the router instance for type safety
 declare module "@tanstack/react-router" {
@@ -9,11 +9,15 @@ declare module "@tanstack/react-router" {
   }
 }
 
-export const router = createRouter({
-  routeTree,
-  context: {
-    apiClient: gardenerApi,
-  },
-  defaultPreload: "intent",
-  scrollRestoration: true,
-})
+export function createAppRouter(mountpoint: string) {
+  const gardenerApi = createGardenerApi(mountpoint)
+
+  return createRouter({
+    routeTree,
+    context: {
+      apiClient: gardenerApi,
+    },
+    defaultPreload: "intent",
+    scrollRestoration: true,
+  })
+}

--- a/plugins/kubernetes_ng/app/views/kubernetes_ng/application/show.html.haml
+++ b/plugins/kubernetes_ng/app/views/kubernetes_ng/application/show.html.haml
@@ -1,6 +1,4 @@
 = content_for :main_toolbar do
   Kubernetes as a Service (Gardener)
 
-
-#kubernetes_ng_app_widget{ data: { basepath: plugin("kubernetes_ng").root_path } }
-  = javascript_include_tag "kubernetes_ng_app_widget", data: { url: plugin("kubernetes_ng").root_path }
+= javascript_include_tag "kubernetes_ng_app_widget", data: {basepath: plugin("kubernetes_ng").root_path, mountpoint: Core::PluginsManager.plugin("kubernetes_ng").mount_point }


### PR DESCRIPTION
# Summary

This change updates the API client to use the mountpoint prop instead of a hardcoded like `kubernetes_ng`, ensuring that all API requests adapt dynamically to the actual plugin mountpoint. By creating the API client with the provided mountpoint and passing it through the router context, the widget no longer depends on fixed strings and avoids breaking when the plugin is mounted under a different path. 

# Changes Made

- Pass as App props the mounting point
- Use the mounting point to retrieve the base path

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
