### PR TITLE
chore(auth): fix js rules by reverting regex changes limited the rule…

### DIFF
--- a/app/javascript/policy_engine.js
+++ b/app/javascript/policy_engine.js
@@ -13,12 +13,10 @@ if (window.policyConfig?.rules && window.policyConfig?.locals) {
   window.policy = {
     isAllowed: function (name, params = {}) {
       const rule = rules[name]
-      if (!rule) throw "Policy Engine Error: rule #{name} not found."
+      if (!rule) throw `Policy Engine Error: rule ${name} not found.`
       return rule(rules, window.policyConfig.locals, params)
     },
   }
 } else {
-  console.info(
-    "Policy engine is not loaded because window.policyConfig does not contain required data"
-  )
+  console.info("Policy engine is not loaded because window.policyConfig does not contain required data")
 }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,7 @@
     %title= page_title
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
     -# = content_for :javascripts do
+
     :javascript
       window.policyConfig = #{policy.try(:to_js).try(:html_safe) || {}}
       window.pluginName = "#{plugin_name}";

--- a/plugins/email_service/app/controllers/email_service/application_controller.rb
+++ b/plugins/email_service/app/controllers/email_service/application_controller.rb
@@ -65,7 +65,6 @@ module EmailService
       Rails.logger.debug("[secret]: #{secret}")
 
       return unless access || secret
-
       @cronus_region = cronus_region
       @aws_region = map_region(@cronus_region) || "eu-central-1"
       @cronus_endpoint = "https://cronus.#{@cronus_region}.cloud.sap"

--- a/plugins/email_service/app/helpers/email_service/application_helper.rb
+++ b/plugins/email_service/app/helpers/email_service/application_helper.rb
@@ -287,6 +287,7 @@ module EmailService
     end
 
     def ses_client_v2
+      @cronus_region = cronus_region
       @region ||= map_region(@cronus_region)
       @endpoint ||= email_service_url
       unless !ec2_creds || ec2_creds.nil?


### PR DESCRIPTION
# Fix Policy Rule Conversion Issues from Ruby to JavaScript

## Problem Description
Recent changes in the `monsoon-openstack-auth` plugin that addressed regex issues introduced a new problem: some policy rules were not being converted correctly from Ruby to JavaScript. 

The root cause was a character limit imposed on individual policy rules. Rules that exceeded this length threshold were being ignored during the conversion process, resulting in incomplete or broken JavaScript rule sets.

## Impact
- **Nested rules affected**: Complex policy rules containing nested conditions were most likely to hit the character limit
- **Silent failures**: Rules exceeding the limit were silently ignored rather than triggering warnings or errors
- **Broken functionality**: Missing rules in JavaScript caused policy evaluation failures in the frontend

## Root Cause
The character length restriction on policy rules was too restrictive for complex, nested rule structures that are common in OpenStack policy definitions.

## Solution
revert last changes for converting rules to javascript.