### PR TITLE
feat(networking): add Archer UI widget for endpoint services

### DIFF
--- a/app/views/application/_main_toolbar.html.haml
+++ b/app/views/application/_main_toolbar.html.haml
@@ -28,11 +28,11 @@
                 -# %div{data: {"react-quota-usage": true, type: plugin_name}} 
 
                 .quota-usage= javascript_include_tag 'resources_usage_widget', defer: true, data: { props: { |
-                  theme: "theme-light",                                        | 
+                  theme: "theme-light",                                        |
                   endpoint: "https://limes-3.#{current_region}.cloud.sap",     |
-                  domainID: "#{@scoped_domain_id}",                            | 
+                  domainID: "#{@scoped_domain_id}",                            |
                   projectID: "#{@scoped_project_id}",                          |
-                  quotaProject: "#{plugin_name}",                              |
+                  quotaProject: "#{@quota_service || plugin_name}",            |
                   getTokenFuncName: "_getCurrentToken",                        |
                   embedded: "true" } } 
                   

--- a/config/navigations/cloud_admin_navigation.rb
+++ b/config/navigations/cloud_admin_navigation.rb
@@ -191,6 +191,14 @@ SimpleNavigation::Configuration.run do |navigation|
                         highlights_on: -> {
                           params[:controller][%r{keppel/?.*}]
                         }
+      cloudops_nav.item :archer,
+                        "All Archer Services",
+                        -> { plugin("networking").archer_widget_path },
+                        if: -> {
+                          plugin_available?(:networking) &&
+                            current_user.has_service?("endpoint-services")
+                        },
+                        highlights_on: %r{networking/widget/archer/?.*}
     end
 
     # primary.item :account, 'Account', nil, html: {class: "fancy-nav-header", 'data-icon': "fa fa-user fa-fw" } do |account_nav|

--- a/config/navigations/services_navigation.rb
+++ b/config/navigations/services_navigation.rb
@@ -346,6 +346,14 @@ SimpleNavigation::Configuration.run do |navigation|
                           highlights_on: lambda {
                             params[:controller][%r{lbaas2/?.*}]
                           }
+      networking_nav.item :archer,
+                          'Endpoint Services',
+                          -> { plugin('networking').archer_widget_path },
+                          if: -> {
+                            plugin_available?(:networking) &&
+                              current_user.has_service?('endpoint-services')
+                          },
+                          highlights_on: %r{networking/widget/archer/?.*}
       networking_nav.item :dns_service,
                           'DNS',
                           -> { plugin('dns_service').zones_path },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@popperjs/core": "^2.11.6",
     "@rails/actioncable": "^7",
     "@react-spring/types": "^10.0.3",
+    "@sapcc/archer-ui": "^2.4.1",
     "@sapcc/limes-ui": "1.18.1",
     "@tanstack/react-query": "^4.28.0",
     "@tanstack/react-router": "1.131.25",

--- a/plugins/networking/app/controllers/networking/widgets_controller.rb
+++ b/plugins/networking/app/controllers/networking/widgets_controller.rb
@@ -5,7 +5,7 @@ module Networking
     authorization_context "networking"
     # enforce permission checks. This will automatically
     # investigate the rule name.
-    authorization_required only: %i[ports bgp_vpns]
+    authorization_required only: %i[ports bgp_vpns archer]
 
     def bgp_vpns
     end
@@ -14,6 +14,12 @@ module Networking
     end
 
     def ports
+    end
+
+    def archer
+      @archer_endpoint = ENV['ARCHER_ENDPOINT'] ||
+        current_user.service_url('endpoint-services')
+      @quota_service = "endpoint_services"
     end
   end
 end

--- a/plugins/networking/app/javascript/widgets/archer/init.js
+++ b/plugins/networking/app/javascript/widgets/archer/init.js
@@ -1,0 +1,18 @@
+// ArcherUI widget - Endpoint as a Service
+// https://github.com/sapcc/archer
+import { mount } from "@sapcc/archer-ui"
+
+const currentScript = document.currentScript
+const wrapper = document.createElement("div")
+const dataset = currentScript.dataset
+wrapper.id = "archer-ui"
+currentScript.replaceWith(wrapper)
+
+let props
+try {
+  props = JSON.parse(dataset?.props)
+} catch (e) {
+  props = {}
+}
+
+mount(wrapper, { props })

--- a/plugins/networking/app/views/networking/widgets/archer.html.haml
+++ b/plugins/networking/app/views/networking/widgets/archer.html.haml
@@ -1,0 +1,2 @@
+- props = { embedded: true, theme: 'theme-light', endpoint: @archer_endpoint, projectID: @scoped_project_id, canEdit: current_user.is_allowed?('networking:archer_edit', {selected: {domain_id: @scoped_domain_id, project_id: @scoped_project_id} }), mockAPI: ENV['ARCHER_MOCK_API'].present?, getTokenFuncName: "_getCurrentToken", cloudAdmin: @scoped_domain_name == 'ccadmin' && @scoped_project_name == 'cloud_admin' }
+= javascript_include_tag 'networking_archer_widget', data: { props: props.to_json }

--- a/plugins/networking/config/policy.json
+++ b/plugins/networking/config/policy.json
@@ -78,5 +78,8 @@
   "networking:bgp_vpn_create": "rule:context_is_network_editor",
   "networking:bgp_vpn_delete": "rule:context_is_network_editor",
 
-  "networking:ip_availability": "rule:context_is_network_viewer"
+  "networking:ip_availability": "rule:context_is_network_viewer",
+
+  "networking:widget_archer": "rule:context_is_network_viewer",
+  "networking:archer_edit": "rule:context_is_network_editor"
 }

--- a/plugins/networking/config/routes.rb
+++ b/plugins/networking/config/routes.rb
@@ -6,6 +6,7 @@ Networking::Engine.routes.draw do
     get "bgp-vpns" => "widgets#bgp_vpns", :on => :collection
     get "security-groups" => "widgets#security_groups", :on => :collection
     get "ports", on: :collection
+    get "archer" => "widgets#archer", :on => :collection
   end
 
   resources :ports, except: %i[edit new] do

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ dependencies:
   '@react-spring/types':
     specifier: ^10.0.3
     version: 10.0.3
+  '@sapcc/archer-ui':
+    specifier: ^2.4.1
+    version: 2.4.1(@types/node@24.10.9)(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.9.3)
   '@sapcc/limes-ui':
     specifier: 1.18.1
     version: 1.18.1(@types/node@24.10.9)(@types/react@18.2.0)(postcss@8.5.6)(react-dom@18.2.0)(react@18.2.0)(typescript@5.9.3)
@@ -3746,6 +3749,25 @@ packages:
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
     dev: true
 
+  /@sapcc/archer-ui@2.4.1(@types/node@24.10.9)(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.9.3):
+    resolution: {integrity: sha512-q1uokqN816NfdfgtY5zBLZ341sPT8QO5/j/ZC24Y19wB4X2b+Royp13oSIvNMWTqfS4uncL3ZfMbrG0enoYwpg==, tarball: https://npm.pkg.github.com/download/@sapcc/archer-ui/2.4.1/cdc9a88d62166a07a0e50bbe1ac3b5410f5a95e0}
+    engines: {node: '>=24.0.0'}
+    dependencies:
+      '@cloudoperators/juno-ui-components': 6.4.0(react-dom@18.2.0)(react@18.2.0)
+      '@tailwindcss/postcss': 4.3.0
+      '@xyflow/react': 12.10.2(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)
+      esbuild: 0.28.0
+      msw: 2.14.6(@types/node@24.10.9)(typescript@5.9.3)
+      react-router: 7.15.1(react-dom@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@types/react'
+      - immer
+      - react
+      - react-dom
+      - typescript
+    dev: false
+
   /@sapcc/limes-ui@1.18.1(@types/node@24.10.9)(@types/react@18.2.0)(postcss@8.5.6)(react-dom@18.2.0)(react@18.2.0)(typescript@5.9.3):
     resolution: {integrity: sha512-wxpdjmrKmteJR9INlO67mE19zr6hXxnDHHBHHSIVpV1JcDQeLCMuD8ByiQrREvbt6xxDh6skepGDQa4003Gbag==, tarball: https://npm.pkg.github.com/download/@sapcc/limes-ui/1.18.1/3fcf0e35e71b6816d3210bcd0a79b11bea2a8f09}
     dependencies:
@@ -4375,8 +4397,20 @@ packages:
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
     dev: false
 
+  /@types/d3-drag@3.0.7:
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+    dependencies:
+      '@types/d3-selection': 3.0.11
+    dev: false
+
   /@types/d3-format@1.4.5:
     resolution: {integrity: sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA==}
+    dev: false
+
+  /@types/d3-interpolate@3.0.4:
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+    dependencies:
+      '@types/d3-color': 3.1.3
     dev: false
 
   /@types/d3-path@2.0.4:
@@ -4395,6 +4429,10 @@ packages:
     resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
     dependencies:
       '@types/d3-time': 3.0.4
+    dev: false
+
+  /@types/d3-selection@3.0.11:
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
     dev: false
 
   /@types/d3-shape@2.1.7:
@@ -4423,6 +4461,19 @@ packages:
 
   /@types/d3-time@3.0.4:
     resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+    dev: false
+
+  /@types/d3-transition@3.0.9:
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+    dependencies:
+      '@types/d3-selection': 3.0.11
+    dev: false
+
+  /@types/d3-zoom@3.0.8:
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
     dev: false
 
   /@types/deep-eql@4.0.2:
@@ -4839,6 +4890,36 @@ packages:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
     dev: true
+
+  /@xyflow/react@12.10.2(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      zustand: 4.5.7(@types/react@18.2.0)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+    dev: false
+
+  /@xyflow/system@0.0.76:
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+    dev: false
 
   /JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -5441,6 +5522,10 @@ packages:
   /ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+    dev: false
+
+  /classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
     dev: false
 
   /classnames@2.5.1:


### PR DESCRIPTION
Adds the Archer UI (Endpoint as a Service) widget to the networking plugin: navigation entry, route, controller wiring, policy, and the haml shell that mounts the widget.

The `@sapcc/archer-ui` npm package is fetched from https://github.com/sapcc/archer/pkgs/npm/archer-ui. Developers need an `.npmrc` configured with a `GITHUB_TOKEN` — see the README's `@sapcc/limes-ui` setup section.