### PR TITLE
fix(kubernetes): use fully-qualified formula name for scikube Homebrew install

### DIFF
--- a/plugins/kubernetes_ng/app/javascript/widgets/app/routes/clusters/-components/HeadingInfo.tsx
+++ b/plugins/kubernetes_ng/app/javascript/widgets/app/routes/clusters/-components/HeadingInfo.tsx
@@ -38,7 +38,7 @@ export default function HeadingInfo() {
           <CodeBlock
             content={`# Install via Homebrew (macOS)
 brew tap sap-cloud-infrastructure/tap
-brew install scikube`}
+brew install sap-cloud-infrastructure/tap/scikube`}
           />
           <p className="tw-my-4">Then source your OpenStack credentials and generate a garden kubeconfig:</p>
 


### PR DESCRIPTION
## Summary

Homebrew 6.0.0 (released 2026-06-11) introduced [tap trust](https://docs.brew.sh/Tap-Trust): formulae from non-official taps are not loaded by default unless the tap is explicitly trusted. The previous instruction:

```sh
brew install scikube
```

no longer works correctly under this model.

Using a **fully-qualified formula name** (`user/repo/formula`) trusts only that specific formula rather than the entire tap — the minimal-trust approach recommended by the official Homebrew docs:

```sh
brew install sap-cloud-infrastructure/tap/scikube
```

> "Prefer trusting the specific formula, cask or command you need. Trust a whole tap only when you are comfortable with all current and future formulae, casks and external commands from that tap being loaded."
> — https://docs.brew.sh/Tap-Trust

## Files changed

- `plugins/kubernetes_ng/.../HeadingInfo.tsx` — one-line fix in the `CodeBlock` content string shown at `/{domain}/{project}/kubernetes-gardener/{landscape}/clusters`

## Test plan

- [ ] Navigate to `/{domain}/{project}/kubernetes-gardener/{landscape}/clusters`
- [ ] Click "Show kubectl Setup Instructions"
- [ ] Confirm the Homebrew block reads `brew install sap-cloud-infrastructure/tap/scikube`