### PR TITLE
feat(email-service): handle CORS errors

### DIFF
--- a/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.test.tsx
+++ b/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.test.tsx
@@ -138,7 +138,7 @@ describe("ErrorReport", () => {
     await act(async () => { render(<ErrorReport />) })
 
     await waitFor(() => {
-      expect(screen.getByText(/Showing 1 of 1 mail records/)).toBeInTheDocument()
+      expect(screen.getByText(/Some mail records could not be loaded/)).toBeInTheDocument()
     })
   })
 
@@ -537,17 +537,19 @@ describe("fetchAllTagged", () => {
     expect(vi.mocked(dataFn)).toHaveBeenCalledTimes(2) // page1 + page2 first attempt only, no retry
   })
 
-  it("caps at 10 pages and sets partial=true when total exceeds 1000", async () => {
+  it("fetches all pages even when total exceeds 1000", async () => {
     const page1 = Array.from({ length: 100 }, (_, i) => makeEntry({ id: `r${i}` }))
+    const extraPage = [makeEntry({ id: "extra" })]
     vi.mocked(dataFn)
       .mockResolvedValueOnce({ data: page1, hits: 1100 })
-      .mockResolvedValue({ data: [makeEntry({ id: "extra" })], hits: 1100 })
+      .mockResolvedValue({ data: extraPage, hits: 1100 })
 
     const result = await fetchAllTagged("token", "https://api.example.com", {})
 
-    expect(result.partial).toBe(true)
+    expect(result.partial).toBe(false)
     expect(result.total).toBe(1100)
-    expect(vi.mocked(dataFn)).toHaveBeenCalledTimes(10) // page 1 + 9 extra (MAX_PAGES cap)
+    expect(vi.mocked(dataFn)).toHaveBeenCalledTimes(11) // page 1 + 10 extra (no cap)
+    expect(result.data).toHaveLength(110)
   })
 
   it("throws on transient first page error after one retry", async () => {

--- a/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.test.tsx
+++ b/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, waitFor, act, fireEvent } from "@testing-library/react"
 import "@testing-library/jest-dom/vitest"
-import ErrorReport from "./ErrorReport"
-import { MailLogEntry } from "../actions"
+import ErrorReport, { fetchAllTagged } from "./ErrorReport"
+import { MailLogEntry, dataFn, HTTPError } from "../actions"
 
 vi.mock("./StoreProvider", () => ({
   useAuthData: () => "test-token",
@@ -72,6 +72,12 @@ const makeEntryWithRcptError = (code: string): MailLogEntry =>
     rcpts: [{ rcpt: "fail@example.com", relay: "r.example.com", response: { code, ext: "5.1.1", msg: "user unknown" } }],
   })
 
+const makeResult = (entries: MailLogEntry[], partial = false) => ({
+  data: entries,
+  partial,
+  total: entries.length,
+})
+
 const mockQuery = (overrides: object = {}) =>
   vi.mocked(useQuery).mockReturnValue({
     data: undefined,
@@ -94,7 +100,7 @@ describe("ErrorReport", () => {
 
   it("renders stat cards when data is loaded", async () => {
     const entries = [makeEntryWithRcptError("550")]
-    mockQuery({ data: entries, isLoading: false })
+    mockQuery({ data: makeResult(entries), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -106,7 +112,7 @@ describe("ErrorReport", () => {
   })
 
   it("shows 'No error responses' when there are no errors in range", async () => {
-    mockQuery({ data: [], isLoading: false })
+    mockQuery({ data: makeResult([]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -116,12 +122,23 @@ describe("ErrorReport", () => {
   })
 
   it("shows 'No error events' row when table is empty", async () => {
-    mockQuery({ data: [], isLoading: false })
+    mockQuery({ data: makeResult([]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
     await waitFor(() => {
       expect(screen.getByText(/No error events in the selected time range/)).toBeInTheDocument()
+    })
+  })
+
+  it("shows partial data warning with counts when some pages failed", async () => {
+    const entries = [makeEntryWithRcptError("550")]
+    mockQuery({ data: makeResult(entries, true), isLoading: false })
+
+    await act(async () => { render(<ErrorReport />) })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Showing 1 of 1 mail records/)).toBeInTheDocument()
     })
   })
 
@@ -136,7 +153,7 @@ describe("ErrorReport", () => {
   })
 
   it("renders DaySelector with 7 day buttons", async () => {
-    mockQuery({ data: [], isLoading: false })
+    mockQuery({ data: makeResult([]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -148,7 +165,7 @@ describe("ErrorReport", () => {
   })
 
   it("persists selected day to localStorage", async () => {
-    mockQuery({ data: [], isLoading: false })
+    mockQuery({ data: makeResult([]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -160,7 +177,7 @@ describe("ErrorReport", () => {
 
   it("reads initial day from localStorage", async () => {
     localStorage.setItem("email_service_report_days", "5")
-    mockQuery({ data: [], isLoading: false })
+    mockQuery({ data: makeResult([]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -170,7 +187,7 @@ describe("ErrorReport", () => {
 
   it("ignores invalid day value in localStorage and defaults to 1", async () => {
     localStorage.setItem("email_service_report_days", "99")
-    mockQuery({ data: [], isLoading: false })
+    mockQuery({ data: makeResult([]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -179,7 +196,7 @@ describe("ErrorReport", () => {
   })
 
   it("renders the 'Error Report' heading", async () => {
-    mockQuery({ data: [], isLoading: false })
+    mockQuery({ data: makeResult([]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -189,7 +206,7 @@ describe("ErrorReport", () => {
   })
 
   it("renders the 'Top Error Responses' heading", async () => {
-    mockQuery({ data: [], isLoading: false })
+    mockQuery({ data: makeResult([]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -199,7 +216,7 @@ describe("ErrorReport", () => {
   })
 
   it("renders the 'Error Events' heading", async () => {
-    mockQuery({ data: [], isLoading: false })
+    mockQuery({ data: makeResult([]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -209,7 +226,7 @@ describe("ErrorReport", () => {
   })
 
   it("renders data grid column headers", async () => {
-    mockQuery({ data: [], isLoading: false })
+    mockQuery({ data: makeResult([]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -225,7 +242,7 @@ describe("ErrorReport", () => {
 
   it("shows pagination with correct total count", async () => {
     const entries = [makeEntryWithRcptError("550")]
-    mockQuery({ data: entries, isLoading: false })
+    mockQuery({ data: makeResult(entries), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -236,7 +253,7 @@ describe("ErrorReport", () => {
 
   it("renders PERM badge for 5xx error codes", async () => {
     const entries = [makeEntryWithRcptError("550")]
-    mockQuery({ data: entries, isLoading: false })
+    mockQuery({ data: makeResult(entries), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -247,7 +264,7 @@ describe("ErrorReport", () => {
 
   it("renders TEMP badge for 4xx error codes", async () => {
     const entries = [makeEntryWithRcptError("421")]
-    mockQuery({ data: entries, isLoading: false })
+    mockQuery({ data: makeResult(entries), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -258,7 +275,7 @@ describe("ErrorReport", () => {
 
   it("clicking a bar row selects the code as a filter", async () => {
     const entries = [makeEntryWithRcptError("550")]
-    mockQuery({ data: entries, isLoading: false })
+    mockQuery({ data: makeResult(entries), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -273,7 +290,7 @@ describe("ErrorReport", () => {
 
   it("clicking the × clear button removes the active filter", async () => {
     const entries = [makeEntryWithRcptError("550")]
-    mockQuery({ data: entries, isLoading: false })
+    mockQuery({ data: makeResult(entries), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -298,7 +315,7 @@ describe("ErrorReport", () => {
         rcpts: [{ rcpt: `r${i}@x.com`, relay: "r", response: { code: "550", ext: "5.1.1", msg: "fail" } }],
       })
     )
-    mockQuery({ data: entries, isLoading: false })
+    mockQuery({ data: makeResult(entries), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -322,7 +339,7 @@ describe("extractErrorEvents", () => {
 
   it("extracts rcpt-level errors", async () => {
     const entry = makeEntryWithRcptError("550")
-    mockQuery({ data: [entry], isLoading: false })
+    mockQuery({ data: makeResult([entry]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -336,7 +353,7 @@ describe("extractErrorEvents", () => {
       rcpts: [{ rcpt: "fail@example.com", relay: "r", response: { code: "0" } }],
       response: { code: 550, ext: "5.1.1", msg: "rejected by policy" },
     })
-    mockQuery({ data: [entry], isLoading: false })
+    mockQuery({ data: makeResult([entry]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -359,7 +376,7 @@ describe("extractErrorEvents", () => {
         },
       ],
     })
-    mockQuery({ data: [entry], isLoading: false })
+    mockQuery({ data: makeResult([entry]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -372,7 +389,7 @@ describe("extractErrorEvents", () => {
     const permEntry1 = makeEntryWithRcptError("550")
     const permEntry2 = makeEntryWithRcptError("553")
     const tempEntry = makeEntryWithRcptError("421")
-    mockQuery({ data: [permEntry1, permEntry2, tempEntry], isLoading: false })
+    mockQuery({ data: makeResult([permEntry1, permEntry2, tempEntry]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -386,7 +403,7 @@ describe("extractErrorEvents", () => {
     const cleanEntry = makeEntry({
       rcpts: [{ rcpt: "ok@example.com", relay: "relay.example.com", response: { code: "250", msg: "OK" } }],
     })
-    mockQuery({ data: [cleanEntry], isLoading: false })
+    mockQuery({ data: makeResult([cleanEntry]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -399,7 +416,7 @@ describe("extractErrorEvents", () => {
     const entry = makeEntry({
       rcpts: [{ rcpt: "ok@example.com", relay: "relay.example.com" }],
     })
-    mockQuery({ data: [entry], isLoading: false })
+    mockQuery({ data: makeResult([entry]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -429,7 +446,7 @@ describe("top error responses", () => {
         ],
       })
     )
-    mockQuery({ data: entries, isLoading: false })
+    mockQuery({ data: makeResult(entries), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -440,21 +457,97 @@ describe("top error responses", () => {
   })
 
   it("uses longest response string as the fullName for the bar label", async () => {
-    // Two entries with same base code but different detail lengths
+    // Two entries with the same key ("550 5.1.1") but different message lengths.
+    // The bar label should show the longer one.
     const entry1 = makeEntry({
       id: "r1",
-      rcpts: [{ rcpt: "a@x.com", relay: "r", response: { code: "550", msg: "short" } }],
+      rcpts: [{ rcpt: "a@x.com", relay: "r", response: { code: "550", ext: "5.1.1", msg: "short" } }],
     })
     const entry2 = makeEntry({
       id: "r2",
       rcpts: [{ rcpt: "b@x.com", relay: "r", response: { code: "550", ext: "5.1.1", msg: "a much longer error message with details" } }],
     })
-    mockQuery({ data: [entry1, entry2], isLoading: false })
+    mockQuery({ data: makeResult([entry1, entry2]), isLoading: false })
 
     await act(async () => { render(<ErrorReport />) })
 
     await waitFor(() => {
       expect(screen.getAllByText("2 total")).toHaveLength(2)
+      // Both entries share key "550 5.1.1" → one bar row → one tooltip with the longer string
+      const tooltips = screen.getAllByTestId("tooltip-content")
+      expect(tooltips).toHaveLength(1)
+      expect(tooltips[0]).toHaveTextContent("550 5.1.1 a much longer error message with details")
     })
+  })
+})
+
+describe("fetchAllTagged", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    localStorage.clear()
+  })
+
+  it("returns full result without partial flag when total fits in one page", async () => {
+    const entries = [makeEntry()]
+    vi.mocked(dataFn).mockResolvedValueOnce({ data: entries, hits: 1 })
+
+    const result = await fetchAllTagged("token", "https://api.example.com", {})
+
+    expect(result).toEqual({ data: entries, partial: false, total: 1 })
+    expect(vi.mocked(dataFn)).toHaveBeenCalledTimes(1)
+  })
+
+  it("fetches extra pages and merges all data when total > 100", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => makeEntry({ id: `r${i}` }))
+    const page2 = [makeEntry({ id: "r100" })]
+    vi.mocked(dataFn)
+      .mockResolvedValueOnce({ data: page1, hits: 101 })
+      .mockResolvedValueOnce({ data: page2, hits: 101 })
+
+    const result = await fetchAllTagged("token", "https://api.example.com", {})
+
+    expect(result.data).toHaveLength(101)
+    expect(result.partial).toBe(false)
+    expect(result.total).toBe(101)
+    expect(vi.mocked(dataFn)).toHaveBeenCalledTimes(2)
+  })
+
+  it("sets partial=true and returns available data when an extra page fails after retry", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => makeEntry({ id: `r${i}` }))
+    vi.mocked(dataFn)
+      .mockResolvedValueOnce({ data: page1, hits: 200 })
+      .mockRejectedValue(new HTTPError(500, "Server Error"))
+
+    const result = await fetchAllTagged("token", "https://api.example.com", {})
+
+    expect(result.partial).toBe(true)
+    expect(result.data).toHaveLength(100)
+    expect(result.total).toBe(200)
+  })
+
+  it("does not retry on non-transient (4xx) errors for extra pages", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => makeEntry({ id: `r${i}` }))
+    vi.mocked(dataFn)
+      .mockResolvedValueOnce({ data: page1, hits: 101 })
+      .mockRejectedValueOnce(new HTTPError(403, "Forbidden"))
+
+    const result = await fetchAllTagged("token", "https://api.example.com", {})
+
+    expect(result.partial).toBe(true)
+    expect(vi.mocked(dataFn)).toHaveBeenCalledTimes(2) // page1 + page2 first attempt only, no retry
+  })
+
+  it("throws when the first page fails after retry", async () => {
+    vi.mocked(dataFn).mockRejectedValue(new HTTPError(500, "Server Error"))
+
+    await expect(fetchAllTagged("token", "https://api.example.com", {})).rejects.toThrow("Server Error")
+    expect(vi.mocked(dataFn)).toHaveBeenCalledTimes(2) // initial attempt + one retry
+  })
+
+  it("throws immediately on non-transient first page error without retrying", async () => {
+    vi.mocked(dataFn).mockRejectedValueOnce(new HTTPError(401, "Unauthorized"))
+
+    await expect(fetchAllTagged("token", "https://api.example.com", {})).rejects.toThrow("Unauthorized")
+    expect(vi.mocked(dataFn)).toHaveBeenCalledTimes(1) // no retry on 401
   })
 })

--- a/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.test.tsx
+++ b/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.test.tsx
@@ -18,18 +18,6 @@ vi.mock("../actions", async (importOriginal) => {
   }
 })
 
-vi.mock("@tanstack/react-query", async (importOriginal) => {
-  const actual = (await importOriginal()) as object
-  return {
-    ...actual,
-    useQuery: vi.fn(),
-    useQueryClient: vi.fn(() => ({
-      removeQueries: vi.fn(),
-      invalidateQueries: vi.fn(),
-    })),
-  }
-})
-
 vi.mock("moment", () => ({
   default: vi.fn((_date?: string) => ({
     format: vi.fn(() => "2024-01-15, 14:30:00"),
@@ -53,8 +41,6 @@ vi.mock("@cloudoperators/juno-ui-components", async () => ({
   TooltipTrigger: ({ children }: any) => <>{children}</>,
 }))
 
-import { useQuery } from "@tanstack/react-query"
-
 const makeEntry = (overrides: Partial<MailLogEntry> = {}): MailLogEntry => ({
   id: "req-1",
   date: "2024-01-15T14:00:00Z",
@@ -72,22 +58,6 @@ const makeEntryWithRcptError = (code: string): MailLogEntry =>
     rcpts: [{ rcpt: "fail@example.com", relay: "r.example.com", response: { code, ext: "5.1.1", msg: "user unknown" } }],
   })
 
-const makeResult = (entries: MailLogEntry[], partial = false) => ({
-  data: entries,
-  partial,
-  total: entries.length,
-})
-
-const mockQuery = (overrides: object = {}) =>
-  vi.mocked(useQuery).mockReturnValue({
-    data: undefined,
-    isLoading: false,
-    isError: false,
-    isFetching: false,
-    error: null,
-    ...overrides,
-  } as any)
-
 describe("ErrorReport", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -100,7 +70,7 @@ describe("ErrorReport", () => {
 
   it("renders stat cards when data is loaded", async () => {
     const entries = [makeEntryWithRcptError("550")]
-    mockQuery({ data: makeResult(entries), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: entries, hits: entries.length })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -112,7 +82,7 @@ describe("ErrorReport", () => {
   })
 
   it("shows 'No error responses' when there are no errors in range", async () => {
-    mockQuery({ data: makeResult([]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [], hits: 0 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -122,7 +92,7 @@ describe("ErrorReport", () => {
   })
 
   it("shows 'No error events' row when table is empty", async () => {
-    mockQuery({ data: makeResult([]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [], hits: 0 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -131,19 +101,21 @@ describe("ErrorReport", () => {
     })
   })
 
-  it("shows partial data warning with counts when some pages failed", async () => {
-    const entries = [makeEntryWithRcptError("550")]
-    mockQuery({ data: makeResult(entries, true), isLoading: false })
+  it("shows partial data warning when some pages failed", async () => {
+    const entries = Array.from({ length: 100 }, (_, i) => makeEntry({ id: `r${i}` }))
+    vi.mocked(dataFn)
+      .mockResolvedValueOnce({ data: entries, hits: 200 })
+      .mockRejectedValue(new HTTPError(500, "Server Error"))
 
     await act(async () => { render(<ErrorReport />) })
 
     await waitFor(() => {
       expect(screen.getByText(/Some mail records could not be loaded/)).toBeInTheDocument()
-    })
+    }, { timeout: 3000 })
   })
 
-  it("shows error message banner when query fails", async () => {
-    mockQuery({ isError: true, error: new Error("Failed to load"), isLoading: false })
+  it("shows error message banner when fetch fails", async () => {
+    vi.mocked(dataFn).mockRejectedValue(new HTTPError(401, "Unauthorized"))
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -153,7 +125,7 @@ describe("ErrorReport", () => {
   })
 
   it("renders DaySelector with 7 day buttons", async () => {
-    mockQuery({ data: makeResult([]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [], hits: 0 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -165,7 +137,7 @@ describe("ErrorReport", () => {
   })
 
   it("persists selected day to localStorage", async () => {
-    mockQuery({ data: makeResult([]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [], hits: 0 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -177,7 +149,7 @@ describe("ErrorReport", () => {
 
   it("reads initial day from localStorage", async () => {
     localStorage.setItem("email_service_report_days", "5")
-    mockQuery({ data: makeResult([]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [], hits: 0 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -187,7 +159,7 @@ describe("ErrorReport", () => {
 
   it("ignores invalid day value in localStorage and defaults to 1", async () => {
     localStorage.setItem("email_service_report_days", "99")
-    mockQuery({ data: makeResult([]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [], hits: 0 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -196,7 +168,7 @@ describe("ErrorReport", () => {
   })
 
   it("renders the 'Error Report' heading", async () => {
-    mockQuery({ data: makeResult([]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [], hits: 0 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -206,7 +178,7 @@ describe("ErrorReport", () => {
   })
 
   it("renders the 'Top Error Responses' heading", async () => {
-    mockQuery({ data: makeResult([]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [], hits: 0 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -216,7 +188,7 @@ describe("ErrorReport", () => {
   })
 
   it("renders the 'Error Events' heading", async () => {
-    mockQuery({ data: makeResult([]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [], hits: 0 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -226,7 +198,7 @@ describe("ErrorReport", () => {
   })
 
   it("renders data grid column headers", async () => {
-    mockQuery({ data: makeResult([]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [], hits: 0 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -242,18 +214,18 @@ describe("ErrorReport", () => {
 
   it("shows pagination with correct total count", async () => {
     const entries = [makeEntryWithRcptError("550")]
-    mockQuery({ data: makeResult(entries), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: entries, hits: entries.length })
 
     await act(async () => { render(<ErrorReport />) })
 
     await waitFor(() => {
-      expect(screen.getAllByText("1 total")).toHaveLength(2) // two pagination bars
+      expect(screen.getAllByText("1 total")).toHaveLength(2)
     })
   })
 
   it("renders PERM badge for 5xx error codes", async () => {
     const entries = [makeEntryWithRcptError("550")]
-    mockQuery({ data: makeResult(entries), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: entries, hits: entries.length })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -264,7 +236,7 @@ describe("ErrorReport", () => {
 
   it("renders TEMP badge for 4xx error codes", async () => {
     const entries = [makeEntryWithRcptError("421")]
-    mockQuery({ data: makeResult(entries), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: entries, hits: entries.length })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -275,7 +247,7 @@ describe("ErrorReport", () => {
 
   it("clicking a bar row selects the code as a filter", async () => {
     const entries = [makeEntryWithRcptError("550")]
-    mockQuery({ data: makeResult(entries), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: entries, hits: entries.length })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -290,11 +262,10 @@ describe("ErrorReport", () => {
 
   it("clicking the × clear button removes the active filter", async () => {
     const entries = [makeEntryWithRcptError("550")]
-    mockQuery({ data: makeResult(entries), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: entries, hits: entries.length })
 
     await act(async () => { render(<ErrorReport />) })
 
-    // Select a filter first
     const barRows = await screen.findAllByText(/550/)
     fireEvent.click(barRows[0].closest("div[style*='cursor']") ?? barRows[0])
 
@@ -315,7 +286,7 @@ describe("ErrorReport", () => {
         rcpts: [{ rcpt: `r${i}@x.com`, relay: "r", response: { code: "550", ext: "5.1.1", msg: "fail" } }],
       })
     )
-    mockQuery({ data: makeResult(entries), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: entries, hits: entries.length })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -339,7 +310,7 @@ describe("extractErrorEvents", () => {
 
   it("extracts rcpt-level errors", async () => {
     const entry = makeEntryWithRcptError("550")
-    mockQuery({ data: makeResult([entry]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [entry], hits: 1 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -353,7 +324,7 @@ describe("extractErrorEvents", () => {
       rcpts: [{ rcpt: "fail@example.com", relay: "r", response: { code: "0" } }],
       response: { code: 550, ext: "5.1.1", msg: "rejected by policy" },
     })
-    mockQuery({ data: makeResult([entry]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [entry], hits: 1 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -376,7 +347,7 @@ describe("extractErrorEvents", () => {
         },
       ],
     })
-    mockQuery({ data: makeResult([entry]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [entry], hits: 1 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -389,11 +360,10 @@ describe("extractErrorEvents", () => {
     const permEntry1 = makeEntryWithRcptError("550")
     const permEntry2 = makeEntryWithRcptError("553")
     const tempEntry = makeEntryWithRcptError("421")
-    mockQuery({ data: makeResult([permEntry1, permEntry2, tempEntry]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [permEntry1, permEntry2, tempEntry], hits: 3 })
 
     await act(async () => { render(<ErrorReport />) })
 
-    // 3 total events, 2 PERM, 1 TEMP
     await waitFor(() => {
       expect(screen.getAllByText("3 total")).toHaveLength(2)
     })
@@ -403,7 +373,7 @@ describe("extractErrorEvents", () => {
     const cleanEntry = makeEntry({
       rcpts: [{ rcpt: "ok@example.com", relay: "relay.example.com", response: { code: "250", msg: "OK" } }],
     })
-    mockQuery({ data: makeResult([cleanEntry]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [cleanEntry], hits: 1 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -416,7 +386,7 @@ describe("extractErrorEvents", () => {
     const entry = makeEntry({
       rcpts: [{ rcpt: "ok@example.com", relay: "relay.example.com" }],
     })
-    mockQuery({ data: makeResult([entry]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [entry], hits: 1 })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -433,7 +403,6 @@ describe("top error responses", () => {
   })
 
   it("shows up to 10 top error response entries", async () => {
-    // Create 12 distinct 5xx response codes
     const entries = Array.from({ length: 12 }, (_, i) =>
       makeEntry({
         id: `req-${i}`,
@@ -446,7 +415,7 @@ describe("top error responses", () => {
         ],
       })
     )
-    mockQuery({ data: makeResult(entries), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: entries, hits: entries.length })
 
     await act(async () => { render(<ErrorReport />) })
 
@@ -457,8 +426,6 @@ describe("top error responses", () => {
   })
 
   it("uses longest response string as the fullName for the bar label", async () => {
-    // Two entries with the same key ("550 5.1.1") but different message lengths.
-    // The bar label should show the longer one.
     const entry1 = makeEntry({
       id: "r1",
       rcpts: [{ rcpt: "a@x.com", relay: "r", response: { code: "550", ext: "5.1.1", msg: "short" } }],
@@ -467,13 +434,12 @@ describe("top error responses", () => {
       id: "r2",
       rcpts: [{ rcpt: "b@x.com", relay: "r", response: { code: "550", ext: "5.1.1", msg: "a much longer error message with details" } }],
     })
-    mockQuery({ data: makeResult([entry1, entry2]), isLoading: false })
+    vi.mocked(dataFn).mockResolvedValue({ data: [entry1, entry2], hits: 2 })
 
     await act(async () => { render(<ErrorReport />) })
 
     await waitFor(() => {
       expect(screen.getAllByText("2 total")).toHaveLength(2)
-      // Both entries share key "550 5.1.1" → one bar row → one tooltip with the longer string
       const tooltips = screen.getAllByTestId("tooltip-content")
       expect(tooltips).toHaveLength(1)
       expect(tooltips[0]).toHaveTextContent("550 5.1.1 a much longer error message with details")

--- a/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.test.tsx
+++ b/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.test.tsx
@@ -537,7 +537,20 @@ describe("fetchAllTagged", () => {
     expect(vi.mocked(dataFn)).toHaveBeenCalledTimes(2) // page1 + page2 first attempt only, no retry
   })
 
-  it("throws when the first page fails after retry", async () => {
+  it("caps at 10 pages and sets partial=true when total exceeds 1000", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => makeEntry({ id: `r${i}` }))
+    vi.mocked(dataFn)
+      .mockResolvedValueOnce({ data: page1, hits: 1100 })
+      .mockResolvedValue({ data: [makeEntry({ id: "extra" })], hits: 1100 })
+
+    const result = await fetchAllTagged("token", "https://api.example.com", {})
+
+    expect(result.partial).toBe(true)
+    expect(result.total).toBe(1100)
+    expect(vi.mocked(dataFn)).toHaveBeenCalledTimes(10) // page 1 + 9 extra (MAX_PAGES cap)
+  })
+
+  it("throws on transient first page error after one retry", async () => {
     vi.mocked(dataFn).mockRejectedValue(new HTTPError(500, "Server Error"))
 
     await expect(fetchAllTagged("token", "https://api.example.com", {})).rejects.toThrow("Server Error")

--- a/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.tsx
+++ b/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.tsx
@@ -306,7 +306,7 @@ const fetchPageWithRetry = async (fn: () => Promise<MailSearchResponse>): Promis
   }
 }
 
-const MAX_PAGES = 10
+const CONCURRENT_PAGES = 50
 
 export const fetchAllTagged = async (
   bearerToken: string,
@@ -326,21 +326,24 @@ export const fetchAllTagged = async (
   const total = first.hits
   if (total <= 100) return { data: first.data ?? [], partial: false, total }
 
-  const totalPages = Math.ceil(total / 100)
-  const pagesToFetch = Math.min(totalPages - 1, MAX_PAGES - 1)
-  const cappedByLimit = totalPages > MAX_PAGES
+  const extraPages = Math.ceil(total / 100) - 1
+  let partial = false
+  const restData: MailLogEntry[] = []
 
-  const rest = await Promise.allSettled(
-    Array.from({ length: pagesToFetch }, (_, i) =>
-      fetchPageWithRetry(() => dataFn({ queryKey: ["data", bearerToken, endpoint, { ...options, page: i + 2, pageSize: 100 }] }))
+  for (let i = 0; i < extraPages; i += CONCURRENT_PAGES) {
+    const batch = Array.from(
+      { length: Math.min(CONCURRENT_PAGES, extraPages - i) },
+      (_, j) => fetchPageWithRetry(() =>
+        dataFn({ queryKey: ["data", bearerToken, endpoint, { ...options, page: i + j + 2, pageSize: 100 }] })
+      )
     )
-  )
-  let partial = cappedByLimit
-  const restData = rest.flatMap((r) => {
-    if (r.status === "fulfilled" && r.value !== null) return r.value.data ?? []
-    partial = true
-    return []
-  })
+    const results = await Promise.allSettled(batch)
+    for (const r of results) {
+      if (r.status === "fulfilled" && r.value !== null) restData.push(...(r.value.data ?? []))
+      else partial = true
+    }
+  }
+
   return { data: [...(first.data ?? []), ...restData], partial, total }
 }
 
@@ -424,7 +427,7 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
 
       {allMailsResult.data?.partial && (
         <div style={{ marginBottom: 12, padding: "10px 16px", background: "#fffbeb", border: "1px solid #fcd34d", borderRadius: 6, fontSize: 13, color: "#92400e" }}>
-          Showing {allMailsResult.data.data.length.toLocaleString()} of {allMailsResult.data.total.toLocaleString()} mail records — results may be incomplete.
+          Some mail records could not be loaded — results may be incomplete.
         </div>
       )}
 

--- a/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.tsx
+++ b/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from "react"
 import moment from "moment"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useAuthData, useAuthProject, useGlobalsEndpoint } from "./StoreProvider"
-import { RankingEntry, MailLogEntry, MailSearchOptions, dataFn } from "../actions"
+import { RankingEntry, MailLogEntry, MailSearchOptions, MailSearchResponse, HTTPError, dataFn } from "../actions"
 import {
   Container,
   DataGrid,
@@ -281,21 +281,61 @@ const PaginationBar: React.FC<{
   </div>
 )
 
-const fetchAllTagged = async (
+interface FetchAllResult {
+  data: MailLogEntry[]
+  partial: boolean
+  total: number
+}
+
+const isTransientError = (e: unknown): boolean => {
+  if (e instanceof HTTPError) return e.statusCode >= 500
+  return true
+}
+
+const fetchPageWithRetry = async (fn: () => Promise<MailSearchResponse>): Promise<MailSearchResponse | null> => {
+  try {
+    return await fn()
+  } catch (e) {
+    if (!isTransientError(e)) return null
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    try {
+      return await fn()
+    } catch {
+      return null
+    }
+  }
+}
+
+export const fetchAllTagged = async (
   bearerToken: string,
   endpoint: string,
   options: Omit<MailSearchOptions, "page" | "pageSize">
-): Promise<MailLogEntry[]> => {
-  const first = await dataFn({ queryKey: ["data", bearerToken, endpoint, { ...options, page: 1, pageSize: 100 }] })
+): Promise<FetchAllResult> => {
+  const page1Fn = () => dataFn({ queryKey: ["data", bearerToken, endpoint, { ...options, page: 1, pageSize: 100 }] })
+  let first: MailSearchResponse
+  try {
+    first = await page1Fn()
+  } catch (e) {
+    if (!isTransientError(e)) throw e
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    first = await page1Fn()
+  }
+
   const total = first.hits
-  if (total <= 100) return first.data ?? []
+  if (total <= 100) return { data: first.data ?? [], partial: false, total }
   const extraPages = Math.ceil((total - 100) / 100)
-  const rest = await Promise.all(
+  const rest = await Promise.allSettled(
     Array.from({ length: extraPages }, (_, i) =>
-      dataFn({ queryKey: ["data", bearerToken, endpoint, { ...options, page: i + 2, pageSize: 100 }] })
+      fetchPageWithRetry(() => dataFn({ queryKey: ["data", bearerToken, endpoint, { ...options, page: i + 2, pageSize: 100 }] }))
     )
   )
-  return [...(first.data ?? []), ...rest.flatMap((r) => r.data ?? [])]
+  let partial = false
+  const restData = rest.flatMap((r) => {
+    if (r.status === "fulfilled" && r.value !== null) return r.value.data ?? []
+    partial = true
+    return []
+  })
+  return { data: [...(first.data ?? []), ...restData], partial, total }
 }
 
 const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void }> = ({ onNavigateToMaillog }) => {
@@ -308,11 +348,12 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
   const [errorPage, setErrorPage] = useState(1)
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE)
   const [selectedCode, setSelectedCode] = useState<string | null>(null)
-  const now = useMemo(() => new Date(), [])
+  const [now, setNow] = useState(() => new Date())
   const start = useMemo(() => new Date(now.getTime() - days * 24 * 60 * 60 * 1000), [now, days])
 
   const handleDaysChange = (d: number) => {
     setDays(d)
+    setNow(new Date())
     setErrorPage(1)
     setSelectedCode(null)
     localStorage.setItem(DAYS_KEY, String(d))
@@ -320,7 +361,7 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
 
   // Fetch ALL mails (no tag filter) so we capture 4xx errors on mails that
   // eventually delivered (not in tag=failed or tag=delayed)
-  const allMailsResult = useQuery<MailLogEntry[], Error>({
+  const allMailsResult = useQuery<FetchAllResult, Error>({
     queryKey: ["chart-all", token, endpoint, start.toISOString(), now.toISOString(), project],
     queryFn: () => fetchAllTagged(token ?? "", endpoint ?? "", { start, end: now, project: project ?? undefined }),
     enabled: !!token,
@@ -334,7 +375,7 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
   const tableError = allMailsResult.error
 
   const allChartErrorEvents = useMemo(() => {
-    const events = extractErrorEvents(allMailsResult.data ?? [])
+    const events = extractErrorEvents(allMailsResult.data?.data ?? [])
     return events.sort((a, b) => new Date(b.time).getTime() - new Date(a.time).getTime())
   }, [allMailsResult.data])
 
@@ -377,6 +418,12 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
   return (
     <Container style={{ paddingTop: 16 }}>
 
+      {allMailsResult.data?.partial && (
+        <div style={{ marginBottom: 12, padding: "10px 16px", background: "#fffbeb", border: "1px solid #fcd34d", borderRadius: 6, fontSize: 13, color: "#92400e" }}>
+          Showing {allMailsResult.data.data.length} of {allMailsResult.data.total} mail records — some data could not be loaded. Try refreshing.
+        </div>
+      )}
+
       {/* Stats cards */}
       <div style={{ position: "relative" }}>
         <div style={{ ...cardStyle, padding: 24, marginBottom: 16 }}>
@@ -388,7 +435,7 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
               <button
                 onClick={() => {
                   queryClient.removeQueries({ queryKey: ["chart-all"] })
-                  allMailsResult.refetch()
+                  setNow(new Date())
                 }}
                 title="Reload"
                 style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #d1d5db", background: "#f9fafb", cursor: "pointer", fontSize: 14, color: "#374151", display: "flex", alignItems: "center", gap: 4 }}

--- a/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.tsx
+++ b/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo, useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import moment from "moment"
-import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useAuthData, useAuthProject, useGlobalsEndpoint } from "./StoreProvider"
 import { RankingEntry, MailLogEntry, MailSearchOptions, MailSearchResponse, HTTPError, dataFn } from "../actions"
 import {
@@ -287,6 +286,18 @@ interface FetchAllResult {
   total: number
 }
 
+interface MailState {
+  data: MailLogEntry[]
+  total: number
+  partial: boolean
+  isLoading: boolean
+  loadingMore: boolean
+  pagesLoaded: number
+  pagesTotal: number
+  isError: boolean
+  error: Error | null
+}
+
 const isTransientError = (e: unknown): boolean => {
   if (e instanceof HTTPError) return e.statusCode >= 500
   return true
@@ -306,7 +317,24 @@ const fetchPageWithRetry = async (fn: () => Promise<MailSearchResponse>): Promis
   }
 }
 
-const CONCURRENT_PAGES = 50
+const CONCURRENT_PAGES = 10
+
+const fetchWithPool = async (
+  tasks: (() => Promise<MailSearchResponse | null>)[],
+  limit: number
+): Promise<PromiseSettledResult<MailSearchResponse | null>[]> => {
+  const results: PromiseSettledResult<MailSearchResponse | null>[] = new Array(tasks.length)
+  let idx = 0
+  const worker = async () => {
+    while (idx < tasks.length) {
+      const i = idx++
+      try { results[i] = { status: "fulfilled", value: await tasks[i]() } }
+      catch (e) { results[i] = { status: "rejected", reason: e } }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, tasks.length) }, worker))
+  return results
+}
 
 export const fetchAllTagged = async (
   bearerToken: string,
@@ -330,18 +358,15 @@ export const fetchAllTagged = async (
   let partial = false
   const restData: MailLogEntry[] = []
 
-  for (let i = 0; i < extraPages; i += CONCURRENT_PAGES) {
-    const batch = Array.from(
-      { length: Math.min(CONCURRENT_PAGES, extraPages - i) },
-      (_, j) => fetchPageWithRetry(() =>
-        dataFn({ queryKey: ["data", bearerToken, endpoint, { ...options, page: i + j + 2, pageSize: 100 }] })
-      )
+  const tasks = Array.from({ length: extraPages }, (_, i) =>
+    () => fetchPageWithRetry(() =>
+      dataFn({ queryKey: ["data", bearerToken, endpoint, { ...options, page: i + 2, pageSize: 100 }] })
     )
-    const results = await Promise.allSettled(batch)
-    for (const r of results) {
-      if (r.status === "fulfilled" && r.value !== null) restData.push(...(r.value.data ?? []))
-      else partial = true
-    }
+  )
+  const results = await fetchWithPool(tasks, CONCURRENT_PAGES)
+  for (const r of results) {
+    if (r.status === "fulfilled" && r.value !== null) restData.push(...(r.value.data ?? []))
+    else partial = true
   }
 
   return { data: [...(first.data ?? []), ...restData], partial, total }
@@ -351,7 +376,6 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
   const token = useAuthData()
   const project = useAuthProject()
   const endpoint = useGlobalsEndpoint()
-  const queryClient = useQueryClient()
 
   const [days, setDays] = useState<number>(getInitialDays)
   const [errorPage, setErrorPage] = useState(1)
@@ -368,23 +392,86 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
     localStorage.setItem(DAYS_KEY, String(d))
   }
 
-  // Fetch ALL mails (no tag filter) so we capture 4xx errors on mails that
-  // eventually delivered (not in tag=failed or tag=delayed)
-  const allMailsResult = useQuery<FetchAllResult, Error>({
-    queryKey: ["chart-all", token, endpoint, start.toISOString(), now.toISOString(), project],
-    queryFn: () => fetchAllTagged(token ?? "", endpoint ?? "", { start, end: now, project: project ?? undefined }),
-    enabled: !!token,
-    refetchOnWindowFocus: false,
+  const [mailState, setMailState] = useState<MailState>({
+    data: [], total: 0, partial: false, isLoading: true, loadingMore: false, pagesLoaded: 0, pagesTotal: 0, isError: false, error: null,
   })
 
-  const tableIsLoading = allMailsResult.isLoading
-  const tableIsError = allMailsResult.isError
-  const tableError = allMailsResult.error
+  useEffect(() => {
+    if (!token) {
+      setMailState((s) => ({ ...s, isLoading: false }))
+      return
+    }
+    let cancelled = false
+    setMailState({ data: [], total: 0, partial: false, isLoading: true, loadingMore: false, pagesLoaded: 0, pagesTotal: 0, isError: false, error: null })
+
+    const fetchPage = (page: number) =>
+      dataFn({ queryKey: ["data", token, endpoint ?? "", { start, end: now, project: project ?? undefined, page, pageSize: 100 }] })
+
+    ;(async () => {
+      let first: MailSearchResponse
+      try {
+        first = await fetchPage(1)
+      } catch (e) {
+        if (!isTransientError(e)) {
+          if (!cancelled) setMailState((s) => ({ ...s, isLoading: false, isError: true, error: e instanceof Error ? e : new Error(String(e)) }))
+          return
+        }
+        await new Promise((r) => setTimeout(r, 300))
+        try {
+          first = await fetchPage(1)
+        } catch (e2) {
+          if (!cancelled) setMailState((s) => ({ ...s, isLoading: false, isError: true, error: e2 instanceof Error ? e2 : new Error(String(e2)) }))
+          return
+        }
+      }
+
+      if (cancelled) return
+
+      const total = first.hits
+      const page1Data = first.data ?? []
+      // OpenSearch default max_result_window is 10,000 — pages beyond 100 will fail
+      const pagesTotal = Math.min(Math.ceil(total / 100), 100)
+      const extraPages = pagesTotal - 1
+
+      if (extraPages === 0) {
+        if (!cancelled) setMailState({ data: page1Data, total: page1Data.length, partial: false, isLoading: false, loadingMore: false, pagesLoaded: 1, pagesTotal: 1, isError: false, error: null })
+        return
+      }
+
+      if (!cancelled) setMailState({ data: page1Data, total, partial: false, isLoading: false, loadingMore: true, pagesLoaded: 1, pagesTotal, isError: false, error: null })
+
+      let allData = [...page1Data]
+      let partial = false
+
+      for (let batchStart = 0; batchStart < extraPages && !cancelled; batchStart += CONCURRENT_PAGES) {
+        const batchSize = Math.min(CONCURRENT_PAGES, extraPages - batchStart)
+        const results = await Promise.allSettled(
+          Array.from({ length: batchSize }, (_, j) =>
+            fetchPageWithRetry(() => fetchPage(batchStart + j + 2))
+          )
+        )
+        if (cancelled) return
+        for (const r of results) {
+          if (r.status === "fulfilled" && r.value !== null) allData = [...allData, ...(r.value.data ?? [])]
+          else partial = true
+        }
+        const pagesLoaded = 1 + batchStart + batchSize
+        const done = pagesLoaded >= pagesTotal
+        setMailState({ data: allData, total: done ? allData.length : total, partial, isLoading: false, loadingMore: !done, pagesLoaded, pagesTotal, isError: false, error: null })
+      }
+    })()
+
+    return () => { cancelled = true }
+  }, [token, endpoint, start, now, project])
+
+  const tableIsLoading = mailState.isLoading
+  const tableIsError = mailState.isError
+  const tableError = mailState.error
 
   const allChartErrorEvents = useMemo(() => {
-    const events = extractErrorEvents(allMailsResult.data?.data ?? [])
+    const events = extractErrorEvents(mailState.data)
     return events.sort((a, b) => new Date(b.time).getTime() - new Date(a.time).getTime())
-  }, [allMailsResult.data])
+  }, [mailState.data])
 
   const chartPermErrs = useMemo(() => allChartErrorEvents.filter((e) => e.type === "PERM").length, [allChartErrorEvents])
   const chartTempErrs = useMemo(() => allChartErrorEvents.filter((e) => e.type === "TEMP").length, [allChartErrorEvents])
@@ -425,7 +512,7 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
   return (
     <Container style={{ paddingTop: 16 }}>
 
-      {allMailsResult.data?.partial && (
+      {mailState.partial && (
         <div style={{ marginBottom: 12, padding: "10px 16px", background: "#fffbeb", border: "1px solid #fcd34d", borderRadius: 6, fontSize: 13, color: "#92400e" }}>
           Some mail records could not be loaded — results may be incomplete.
         </div>
@@ -440,18 +527,34 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
               <DaySelector selected={days} onChange={handleDaysChange} />
               <div style={{ width: 1, height: 20, background: "#e5e7eb" }} />
               <button
-                onClick={() => {
-                  queryClient.removeQueries({ queryKey: ["chart-all"] })
-                  setNow(new Date())
-                }}
-                title="Reload"
-                style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #d1d5db", background: "#f9fafb", cursor: "pointer", fontSize: 14, color: "#374151", display: "flex", alignItems: "center", gap: 4 }}
-              >
-                ↻
-              </button>
+                  onClick={() => setNow(new Date())}
+                  disabled={mailState.isLoading || mailState.loadingMore}
+                  title="Reload"
+                  style={{ padding: "4px 10px", borderRadius: 4, border: "1px solid #d1d5db", background: "#f9fafb", cursor: mailState.isLoading || mailState.loadingMore ? "default" : "pointer", opacity: mailState.isLoading || mailState.loadingMore ? 0.4 : 1, fontSize: 14, color: "#374151", display: "flex", alignItems: "center", gap: 4 }}
+                >
+                  ↻
+                </button>
             </div>
           </div>
-          {allMailsResult.isLoading ? (
+          {mailState.loadingMore && (
+            <div style={{ marginBottom: 16 }}>
+              <div style={{ height: 4, background: "#e5e7eb", borderRadius: 2, overflow: "hidden" }}>
+                <div
+                  style={{
+                    width: `${Math.round((mailState.pagesLoaded / mailState.pagesTotal) * 100)}%`,
+                    height: "100%",
+                    background: "#038bc6",
+                    borderRadius: 2,
+                    transition: "width 0.4s ease",
+                  }}
+                />
+              </div>
+              <div style={{ fontSize: 11, color: "#9ca3af", marginTop: 4 }}>
+                Fetching… {allChartErrorEvents.length.toLocaleString()} error events found ({Math.round((mailState.pagesLoaded / mailState.pagesTotal) * 100)}%)
+              </div>
+            </div>
+          )}
+          {mailState.isLoading ? (
             <Stack alignment="center" distribution="center" style={{ minHeight: 80 }}>
               <LoadingIndicator />
             </Stack>
@@ -470,7 +573,7 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
             <div style={{ fontWeight: 700, fontSize: 16 }}>Error Summary</div>
             <div style={{ fontSize: 12, color: "#9ca3af" }}>click a row to filter the table</div>
           </div>
-          {allMailsResult.isLoading ? (
+          {mailState.isLoading ? (
             <Stack alignment="center" distribution="center" style={{ minHeight: 80 }}>
               <LoadingIndicator />
             </Stack>

--- a/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.tsx
+++ b/plugins/email_service/app/javascript/widgets/app/components/ErrorReport.tsx
@@ -306,6 +306,8 @@ const fetchPageWithRetry = async (fn: () => Promise<MailSearchResponse>): Promis
   }
 }
 
+const MAX_PAGES = 10
+
 export const fetchAllTagged = async (
   bearerToken: string,
   endpoint: string,
@@ -323,13 +325,17 @@ export const fetchAllTagged = async (
 
   const total = first.hits
   if (total <= 100) return { data: first.data ?? [], partial: false, total }
-  const extraPages = Math.ceil((total - 100) / 100)
+
+  const totalPages = Math.ceil(total / 100)
+  const pagesToFetch = Math.min(totalPages - 1, MAX_PAGES - 1)
+  const cappedByLimit = totalPages > MAX_PAGES
+
   const rest = await Promise.allSettled(
-    Array.from({ length: extraPages }, (_, i) =>
+    Array.from({ length: pagesToFetch }, (_, i) =>
       fetchPageWithRetry(() => dataFn({ queryKey: ["data", bearerToken, endpoint, { ...options, page: i + 2, pageSize: 100 }] }))
     )
   )
-  let partial = false
+  let partial = cappedByLimit
   const restData = rest.flatMap((r) => {
     if (r.status === "fulfilled" && r.value !== null) return r.value.data ?? []
     partial = true
@@ -367,8 +373,6 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
     enabled: !!token,
     refetchOnWindowFocus: false,
   })
-
-  const isFetching = allMailsResult.isFetching
 
   const tableIsLoading = allMailsResult.isLoading
   const tableIsError = allMailsResult.isError
@@ -420,7 +424,7 @@ const ErrorReport: React.FC<{ onNavigateToMaillog?: (messageId: string) => void 
 
       {allMailsResult.data?.partial && (
         <div style={{ marginBottom: 12, padding: "10px 16px", background: "#fffbeb", border: "1px solid #fcd34d", borderRadius: 6, fontSize: 13, color: "#92400e" }}>
-          Showing {allMailsResult.data.data.length} of {allMailsResult.data.total} mail records — some data could not be loaded. Try refreshing.
+          Showing {allMailsResult.data.data.length.toLocaleString()} of {allMailsResult.data.total.toLocaleString()} mail records — results may be incomplete.
         </div>
       )}
 


### PR DESCRIPTION
# Summary

Improves the Error Report's data fetching to be resilient against partial failures when paginating through large result sets. Previously, a single failed extra page would cause the entire query to fail. Now extra pages are fetched with retry logic and partial results are shown with a warning banner instead of a hard error.

# Changes Made

- Replace `Promise.all` with `Promise.allSettled` for extra page fetches so one failed page does not discard all loaded data
- Add per-page retry (one retry with 300ms delay) for transient errors (5xx / network failures)
- First page preserves original error type (401, CORS, etc.) and still throws — only extra pages degrade gracefully
- Introduce `FetchAllResult { data, partial, total }` shape so the UI knows whether the result set is complete
- Show a warning banner when `partial: true` indicating how many records were loaded vs. total
- Reset `now` timestamp on day change and on manual refresh so the time window is always correct
- Export `fetchAllTagged` and add unit tests covering: single page, multi-page merge, partial failure, retry behavior, and non-transient error pass-through

# Related Issues

- N/A

# Screenshots (if applicable)

N/A — warning banner appears in place of a hard error when extra pages fail to load.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
