### PR TITLE
fix(core): pin pnpm to 8.15.0 in checks workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -96,8 +96,12 @@ jobs:
         with:
           node-version: "22.x"
 
+      # Pin pnpm to the version declared in package.json ("packageManager": "pnpm@8.15.0").
+      # An unpinned "npm install -g pnpm" pulls the latest pnpm, which no longer supports
+      # our lockfileVersion 6.0 (ERR_PNPM_BROKEN_LOCKFILE) and skips optional native
+      # bindings on --frozen-lockfile. Keep this in sync with package.json.
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@8.15.0
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -141,8 +145,12 @@ jobs:
         with:
           node-version: "22.x"
 
+      # Pin pnpm to the version declared in package.json ("packageManager": "pnpm@8.15.0").
+      # An unpinned "npm install -g pnpm" pulls the latest pnpm, which no longer supports
+      # our lockfileVersion 6.0 (ERR_PNPM_BROKEN_LOCKFILE) and skips optional native
+      # bindings on --frozen-lockfile. Keep this in sync with package.json.
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@8.15.0
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -186,8 +194,12 @@ jobs:
         with:
           node-version: "22.x"
 
+      # Pin pnpm to the version declared in package.json ("packageManager": "pnpm@8.15.0").
+      # An unpinned "npm install -g pnpm" pulls the latest pnpm, which no longer supports
+      # our lockfileVersion 6.0 (ERR_PNPM_BROKEN_LOCKFILE) and skips optional native
+      # bindings on --frozen-lockfile. Keep this in sync with package.json.
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@8.15.0
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
   "version": "2.0.0",
   "repository": "https://github.com/sapcc/elektra.git",
   "main": "index.js",
+  "//packageManager": "Keep in sync with .github/workflows/checks.yaml (npm install -g pnpm@8.15.0). Our pnpm-lock.yaml uses lockfileVersion 6.0, which newer pnpm majors no longer support. When bumping pnpm: update this field AND checks.yaml to the same version, run `pnpm install` (without --frozen-lockfile) to migrate the lockfile, and commit the regenerated pnpm-lock.yaml.",
   "packageManager": "pnpm@8.15.0",
   "engines": {
     "node": ">=16.14.0",


### PR DESCRIPTION
# Summary

The `checks.yaml` workflow installs pnpm with an unpinned `npm install -g pnpm`, which pulls the **latest** pnpm major (currently 12.x). Newer pnpm majors no longer support our `pnpm-lock.yaml` format (`lockfileVersion: 6.0`) and fail with `ERR_PNPM_BROKEN_LOCKFILE`, and on `--frozen-lockfile` they skip optional platform-specific native bindings. This surfaced as `Cannot find native binding … @rolldown/binding-linux-x64-gnu` in the JavaScript tests job.

This PR pins the CI to `pnpm@8.15.0` — the version already declared in `package.json` (`"packageManager": "pnpm@8.15.0"`) and used in the dev container — so CI, the dev container, and local greenfield installs all resolve the same pnpm.

# Root Cause

- The repo pins pnpm via `package.json` → `"packageManager": "pnpm@8.15.0"` (lockfileVersion 6.0). The dev container installs exactly this version, so tests pass there.
- CI bypasses that pin: `npm install -g pnpm` ignores the `packageManager` field and installs whatever is latest on npm.
- This mismatch was latent for a long time — pnpm 8/9 could still read lockfileVersion 6.0. It only became fatal once the latest pnpm major **dropped** support for that lockfile format (`ERR_PNPM_BROKEN_LOCKFILE`).
- It became **visible** at the same time because vite 8.2.2 (#2145) pulled in `rolldown`, whose optional native binding is skipped by the broken/incompatible install, crashing `pnpm test` with "Cannot find native binding".
- Verified locally: a fresh install (empty store, `--frozen-lockfile`) with **pnpm 8.15.0** installs the native binding and succeeds; with **pnpm 12** it fails on the lockfile format. So the pnpm version — not rolldown, the cache, or the Rails upgrade — is the cause.

# Changes Made

- Pin all three pnpm installs in `.github/workflows/checks.yaml` (JavaScript tests, TypeScript check, Lint check) to `npm install -g pnpm@8.15.0`, each with an explanatory comment.
- Add a `//packageManager` note in `package.json` pointing to the workflow so the two versions are kept in sync.

# When upgrading pnpm

The pnpm version is now pinned in **two** places that must stay in sync:

1. `package.json` → `"packageManager": "pnpm@<version>"`
2. `.github/workflows/checks.yaml` → `npm install -g pnpm@<version>` (three jobs: JavaScript tests, TypeScript check, Lint check)

To bump pnpm:

1. Update the version in **both** places to the same value.
2. Run `pnpm install` **without** `--frozen-lockfile` locally to migrate `pnpm-lock.yaml` to the new `lockfileVersion`, and commit the regenerated lockfile.
3. Update the dev container image to install the same pnpm version.
4. If moving to pnpm 10+, note that the `pnpm.*` config in `package.json` (e.g. `pnpm.overrides`) is no longer read there and must be migrated (see https://pnpm.io/settings) — otherwise our security overrides are silently ignored.
5. Consider switching CI to `pnpm/action-setup` + corepack so `packageManager` becomes the single source of truth and this dual-pinning is no longer needed.

# Related Issues

- Surfaced while working on the Rails 8.1 upgrade PR (unrelated root cause; CI-only).

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
