### PR TITLE
Add Manila mount point name support

### DIFF
--- a/plugins/shared_filesystem_storage/app/controllers/shared_filesystem_storage/shares_controller.rb
+++ b/plugins/shared_filesystem_storage/app/controllers/shared_filesystem_storage/shares_controller.rb
@@ -131,6 +131,7 @@ module SharedFilesystemStorage
         :share_network_id,
         :consistency_group_id,
         :availability_zone,
+        :mount_point_name,
       )
     end
   end

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/shares/item.test.tsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/shares/item.test.tsx
@@ -28,6 +28,8 @@ const mockIsShareStatusPending = vi.hoisted(() => vi.fn().mockReturnValue(false)
 
 vi.mock("../../constants", () => ({
   isShareStatusPending: mockIsShareStatusPending,
+  SHARE_STATE_CREATING: "creating",
+  SHARE_STATE_CREATING_FROM_SNAPSHOT: "creating_from_snapshot",
 }))
 
 vi.mock("./actions", () => ({
@@ -116,6 +118,12 @@ describe("ShareItem", () => {
 
     it("shows spinner when status is creating", () => {
       const share = { ...mockShare, status: "creating" }
+      render(<table><tbody><ShareItem {...defaultProps} share={share} /></tbody></table>)
+      expect(document.querySelector(".spinner")).toBeInTheDocument()
+    })
+
+    it("shows spinner when status is creating from snapshot", () => {
+      const share = { ...mockShare, status: "creating_from_snapshot" }
       render(<table><tbody><ShareItem {...defaultProps} share={share} /></tbody></table>)
       expect(document.querySelector(".spinner")).toBeInTheDocument()
     })

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/shares/item.tsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/shares/item.tsx
@@ -69,6 +69,9 @@ const ShareItem: React.FC<ShareItemProps> = ({
 }) => {
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const isPending = constants.isShareStatusPending(share.status)
+  const isCreating =
+    share.status === constants.SHARE_STATE_CREATING ||
+    share.status === constants.SHARE_STATE_CREATING_FROM_SNAPSHOT
 
   useEffect(() => {
     loadShareRulesOnce(share.id)
@@ -104,7 +107,7 @@ const ShareItem: React.FC<ShareItemProps> = ({
       <td>{share.share_proto}</td>
       <td>{(share.size || 0) + " GB"}</td>
       <td>
-        {share.status === "creating" && <span className="spinner"></span>}
+        {isCreating && <span className="spinner"></span>}
         {share.status}
       </td>
       <td>

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/shares/new.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/shares/new.jsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom"
 import React from "react"
 
 const protocols = ["NFS", "CIFS", "MULTI"]
+const mountPointNamePattern = /^[a-zA-Z0-9_-]{0,255}$/
 
 export default class NewShareForm extends React.Component {
   constructor(props) {
@@ -20,7 +21,17 @@ export default class NewShareForm extends React.Component {
   }
 
   validate(values) {
-    return values.share_proto && values.size && values.share_network_id && true
+    const isValidMountPointName =
+      !values.mount_point_name ||
+      mountPointNamePattern.test(values.mount_point_name)
+
+    return (
+      values.share_proto &&
+      values.size &&
+      values.share_network_id &&
+      isValidMountPointName &&
+      true
+    )
   }
 
   close(e) {
@@ -141,6 +152,26 @@ export default class NewShareForm extends React.Component {
               />
               <p className="help-block">
                 The UUID of the share’s base snapshot.
+              </p>
+            </Form.ElementHorizontal>
+
+            <Form.ElementHorizontal
+              label="Mount Point Name"
+              name="mount_point_name"
+              required={false}
+            >
+              <Form.Input
+                elementType="input"
+                className="optional form-control"
+                type="text"
+                name="mount_point_name"
+                maxLength={255}
+                pattern="[a-zA-Z0-9_-]*"
+                title="Use only letters, numbers, underscores, and hyphens."
+              />
+              <p className="help-block">
+                Optional human-readable mount point name, reflected in the
+                share's export location once created.
               </p>
             </Form.ElementHorizontal>
 

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/constants.js
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/constants.js
@@ -133,6 +133,7 @@ export const CASTELLUM_ASSET_SCRAPE = { key: "assets", endpoint: "/projects/:id/
 
 //####################### SHARE STATES ########################
 export const SHARE_STATE_CREATING = "creating" //The share is being created.
+export const SHARE_STATE_CREATING_FROM_SNAPSHOT = "creating_from_snapshot" //The share is being created from a snapshot.
 export const SHARE_STATE_AVAILABLE = "available" //The share is ready to use.
 export const SHARE_STATE_DELETING = "deleting" //The share is being deleted.
 export const SHARE_STATE_ERROR = "error" //A share creation error occurred.
@@ -143,6 +144,7 @@ export const SHARE_STATE_MIGRATING_TO = "migrating_to" //A share deletion error 
 
 const SHARE_PENDING_STATUS = [
   SHARE_STATE_CREATING,
+  SHARE_STATE_CREATING_FROM_SNAPSHOT,
   SHARE_STATE_DELETING,
   SHARE_STATE_MIGRATING,
   SHARE_STATE_MIGRATING_TO,

--- a/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/share.rb
+++ b/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/share.rb
@@ -90,7 +90,16 @@ module ServiceLayer
 
       ################# INTERFACE METHODS ######################
       def create_share(params)
-        elektron_shares.post("shares") { { share: params } }.body["share"]
+        elektron_shares
+          .post(
+            "shares",
+            headers: {
+              "X-OpenStack-Manila-API-Version" => "2.84",
+            },
+          ) do
+            { share: params }
+          end
+          .body["share"]
       end
 
       def update_share(share_id, params)


### PR DESCRIPTION
## Summary
- send Manila share create requests with API microversion 2.84
- pass the new mount_point_name create option through strong params and the share create form
- treat creating_from_snapshot as a pending share state so polling/spinners continue to work after the microversion bump

## Tests
- corepack pnpm test -- plugins/shared_filesystem_storage/app/javascript/widgets/app/components/shares/item.test.tsx
- RBENV_VERSION=system ruby -c plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/share.rb
- RBENV_VERSION=system ruby -c plugins/shared_filesystem_storage/app/controllers/shared_filesystem_storage/shares_controller.rb
