### PR TITLE
fix(core): set HSTS header on all production responses

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,6 +61,14 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
+  # Set HSTS on every response — including the unauthenticated 302 redirect to the login
+  # form — so browsers learn the HTTPS-only policy on first contact, protecting against
+  # SSL-stripping. We set the header directly instead of enabling config.force_ssl: TLS is
+  # terminated at the nginx ingress and the container serves plain HTTP on port 80, so
+  # force_ssl would 301-redirect the internal HTTP health probes and break the deployment.
+  config.action_dispatch.default_headers["Strict-Transport-Security"] =
+    "max-age=31536000; includeSubDomains"
+
   # Prepend all log lines with the following tags.
   config.log_tags = [:uuid]
   config.logger = RailsStdoutLogging::Rails.heroku_stdout_logger

--- a/spec/integration/hsts_header_integration_spec.rb
+++ b/spec/integration/hsts_header_integration_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-# Regression test for the HSTS security finding (CVSS 5.6, configuration):
+# Regression test for the HSTS security finding:
 # the Strict-Transport-Security header must be set on *every* production response
 # — including the unauthenticated 302 redirect to the login form — so browsers
 # learn the HTTPS-only policy on first contact and are protected against

--- a/spec/integration/hsts_header_integration_spec.rb
+++ b/spec/integration/hsts_header_integration_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Regression test for the HSTS security finding (CVSS 5.6, configuration):
+# the Strict-Transport-Security header must be set on *every* production response
+# — including the unauthenticated 302 redirect to the login form — so browsers
+# learn the HTTPS-only policy on first contact and are protected against
+# SSL-stripping.
+#
+# The header is configured via config.action_dispatch.default_headers in
+# config/environments/production.rb. The test suite boots in the "test"
+# environment, so we cannot observe the production default headers on a live
+# request here; instead we assert the production environment file configures the
+# header with the expected policy. Setting it as a default header (rather than
+# enabling config.force_ssl) guarantees it is emitted on all responses without an
+# HTTP->HTTPS redirect that would break the plain-HTTP health probes behind the
+# TLS-terminating ingress.
+describe "HSTS default header (production)" do
+  let(:production_env_source) do
+    Rails.root.join("config", "environments", "production.rb").read
+  end
+
+  it "configures Strict-Transport-Security as a default header" do
+    expect(production_env_source).to match(
+      /config\.action_dispatch\.default_headers\[["']Strict-Transport-Security["']\]/,
+    )
+  end
+
+  it "uses a one-year max-age and includes subdomains" do
+    expect(production_env_source).to match(/max-age=31536000/)
+    expect(production_env_source).to match(/includeSubDomains/)
+  end
+
+  it "does not enable force_ssl (would break plain-HTTP health probes)" do
+    active_lines =
+      production_env_source.lines.reject { |line| line.strip.start_with?("#") }
+    expect(active_lines.join).not_to match(/config\.force_ssl\s*=\s*true/)
+  end
+end


### PR DESCRIPTION
# Summary

Fixes a security finding: the `Strict-Transport-Security` (HSTS) header was only added by the ingress/proxy for authenticated traffic. The unauthenticated 302 redirect to the login form went out without HSTS, leaving the initial request exposed to SSL-stripping. This PR sets HSTS on **every** production response so browsers learn the HTTPS-only policy on first contact.

# Changes Made

- Set `Strict-Transport-Security: max-age=31536000; includeSubDomains` via `config.action_dispatch.default_headers` in `config/environments/production.rb`, so it is emitted on all responses (including the unauthenticated 302).
- Add a regression spec verifying the production env configures the header with the expected policy and does not enable `force_ssl`.

# Why not `config.force_ssl`?

TLS is terminated at the nginx ingress (`elektra-tls` cert); the container serves plain HTTP on port 80. Enabling `force_ssl` would 301-redirect the internal HTTP health probes (which have no `X-Forwarded-Proto: https`) and break the deployment. A default response header sets HSTS without any redirect/cookie side effects, and the ingress passes the header through to the browser over HTTPS.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.